### PR TITLE
Fix attempt idl attributes from children

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,7 +1,6 @@
 name: Scapy RPC unit tests
 
 on:
-  workflow_dispatch:
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,6 +1,7 @@
 name: Scapy RPC unit tests
 
 on:
+  workflow_dispatch:
   push:
     branches: [master]
   pull_request:

--- a/midl-to-scapy/midl_resolve.py
+++ b/midl-to-scapy/midl_resolve.py
@@ -456,7 +456,7 @@ class Resolver:
                 SCAPY_FIELDS[arg.fmt],
                 arg.type,
                 idl_attributes=idl_attributes,
-                default_idl_attribute=default_idl_attribute
+                default_idl_attribute=default_idl_attribute,
             )
         elif arg.TYPE == Types.CUSTOM:
             if isinstance(new_arg, ScapyStructField):
@@ -466,7 +466,7 @@ class Resolver:
                     new_arg.subtype,
                     new_arg.subtype.name,
                     idl_attributes=idl_attributes,
-                    default_idl_attribute=default_idl_attribute
+                    default_idl_attribute=default_idl_attribute,
                 )
             elif isinstance(new_arg, ScapyUnion):
                 return ScapyUnion(
@@ -475,7 +475,7 @@ class Resolver:
                     new_arg.fields,
                     idl_attributes=idl_attributes,
                     struct_name=new_arg.struct_name,
-                    default_idl_attribute=default_idl_attribute
+                    default_idl_attribute=default_idl_attribute,
                 )
             elif isinstance(new_arg, ScapyStruct):
                 return ScapyStructField(
@@ -484,7 +484,7 @@ class Resolver:
                     new_arg,
                     new_arg.name,
                     idl_attributes=idl_attributes,
-                    default_idl_attribute=default_idl_attribute
+                    default_idl_attribute=default_idl_attribute,
                 )
             elif isinstance(new_arg, ScapyField):
                 return ScapyField(
@@ -493,7 +493,7 @@ class Resolver:
                     new_arg.scapy_field,
                     arg.type,
                     idl_attributes=idl_attributes,
-                    default_idl_attribute=default_idl_attribute
+                    default_idl_attribute=default_idl_attribute,
                 )
             else:
                 assert False, "Unimplemented Custom->%s" % repr(arg.type)

--- a/midl-to-scapy/scapy_obj.py
+++ b/midl-to-scapy/scapy_obj.py
@@ -372,7 +372,15 @@ def get_alignment(field):
 
 
 class ScapyField:
-    def __init__(self, name, ptr_lvl, scapy_field, field_type_name, idl_attributes, default_idl_attribute = None):
+    def __init__(
+        self,
+        name,
+        ptr_lvl,
+        scapy_field,
+        field_type_name,
+        idl_attributes,
+        default_idl_attribute=None,
+    ):
         self.name = name
         self.ptr_lvl = ptr_lvl
         self.sz = SCAPY_SIZES.get(scapy_field, 1)
@@ -607,9 +615,22 @@ class ScapyArrayField(ScapyField):
 
 
 class ScapyStructField(ScapyField):
-    def __init__(self, name, ptr_lvl, subtype, struct_name, idl_attributes, default_idl_attribute = None):
+    def __init__(
+        self,
+        name,
+        ptr_lvl,
+        subtype,
+        struct_name,
+        idl_attributes,
+        default_idl_attribute=None,
+    ):
         super(ScapyStructField, self).__init__(
-            name, ptr_lvl, "NDRPacketField", struct_name, idl_attributes, default_idl_attribute
+            name,
+            ptr_lvl,
+            "NDRPacketField",
+            struct_name,
+            idl_attributes,
+            default_idl_attribute,
         )
         self.subtype = subtype
         self.struct_name = struct_name
@@ -670,7 +691,14 @@ class ScapyStructField(ScapyField):
 
 class ScapyStruct:
     def __init__(
-        self, name, ptr_lvl, fields, idl_attributes, struct_name, recursive=False, default_idl_attribute = None
+        self,
+        name,
+        ptr_lvl,
+        fields,
+        idl_attributes,
+        struct_name,
+        recursive=False,
+        default_idl_attribute=None,
     ):
         self.name = name
         self.ptr_lvl = ptr_lvl
@@ -777,9 +805,22 @@ class ScapyStruct:
 
 
 class ScapyUnion(ScapyStruct, ScapyField):
-    def __init__(self, name, ptr_lvl, fields, idl_attributes, struct_name, default_idl_attribute = None):
+    def __init__(
+        self,
+        name,
+        ptr_lvl,
+        fields,
+        idl_attributes,
+        struct_name,
+        default_idl_attribute=None,
+    ):
         super(ScapyUnion, self).__init__(
-            name, ptr_lvl, fields, idl_attributes, struct_name, default_idl_attribute=default_idl_attribute
+            name,
+            ptr_lvl,
+            fields,
+            idl_attributes,
+            struct_name,
+            default_idl_attribute=default_idl_attribute,
         )
         self.field_type = name
         for f in self.fields:

--- a/midl-to-scapy/scapy_obj.py
+++ b/midl-to-scapy/scapy_obj.py
@@ -372,13 +372,14 @@ def get_alignment(field):
 
 
 class ScapyField:
-    def __init__(self, name, ptr_lvl, scapy_field, field_type_name, idl_attributes):
+    def __init__(self, name, ptr_lvl, scapy_field, field_type_name, idl_attributes, default_idl_attribute = None):
         self.name = name
         self.ptr_lvl = ptr_lvl
         self.sz = SCAPY_SIZES.get(scapy_field, 1)
         self.scapy_field = scapy_field
         self.field_type = field_type_name
         self.idl_attributes = idl_attributes
+        self.default_idl_attribute = default_idl_attribute
         self.inv_length_or_size_is = None
         assert not ptr_lvl or any(
             x in ("ref", "unique", "ptr") for x in idl_attributes
@@ -606,9 +607,9 @@ class ScapyArrayField(ScapyField):
 
 
 class ScapyStructField(ScapyField):
-    def __init__(self, name, ptr_lvl, subtype, struct_name, idl_attributes):
+    def __init__(self, name, ptr_lvl, subtype, struct_name, idl_attributes, default_idl_attribute = None):
         super(ScapyStructField, self).__init__(
-            name, ptr_lvl, "NDRPacketField", struct_name, idl_attributes
+            name, ptr_lvl, "NDRPacketField", struct_name, idl_attributes, default_idl_attribute
         )
         self.subtype = subtype
         self.struct_name = struct_name
@@ -669,7 +670,7 @@ class ScapyStructField(ScapyField):
 
 class ScapyStruct:
     def __init__(
-        self, name, ptr_lvl, fields, idl_attributes, struct_name, recursive=False
+        self, name, ptr_lvl, fields, idl_attributes, struct_name, recursive=False, default_idl_attribute = None
     ):
         self.name = name
         self.ptr_lvl = ptr_lvl
@@ -677,6 +678,7 @@ class ScapyStruct:
         self.idl_attributes = idl_attributes
         self.struct_name = struct_name
         self.recursive = recursive
+        self.default_idl_attribute = default_idl_attribute
         if recursive:
             # Super hack. A recursive field is only refered to by other fields,
             # not actually built into a Scapy structure. So we hack its name
@@ -775,9 +777,9 @@ class ScapyStruct:
 
 
 class ScapyUnion(ScapyStruct, ScapyField):
-    def __init__(self, name, ptr_lvl, fields, idl_attributes, struct_name):
+    def __init__(self, name, ptr_lvl, fields, idl_attributes, struct_name, default_idl_attribute = None):
         super(ScapyUnion, self).__init__(
-            name, ptr_lvl, fields, idl_attributes, struct_name
+            name, ptr_lvl, fields, idl_attributes, struct_name, default_idl_attribute=default_idl_attribute
         )
         self.field_type = name
         for f in self.fields:

--- a/scapy-rpc/msrpcs/ept.py
+++ b/scapy-rpc/msrpcs/ept.py
@@ -202,7 +202,7 @@ class ept_mgmt_delete_Request(NDRPacket):
     fields_desc = [
         NDRIntField("object_speced", 0),
         NDRPacketField("object", uuid_p_t(), uuid_p_t),
-        NDRPacketField("tower", twr_p_t(), twr_p_t),
+        NDRFullPointerField(NDRPacketField("tower", twr_p_t(), twr_p_t)),
     ]
 
 

--- a/scapy-rpc/msrpcs/mc_ccfg.py
+++ b/scapy-rpc/msrpcs/mc_ccfg.py
@@ -1012,12 +1012,14 @@ class Invoke_Request(NDRPacket):
         NDRConfFieldListField(
             "rgVarRefIdx", [], NDRIntField("", 0), size_is=lambda pkt: pkt.cVarRef
         ),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
     ]
 
@@ -1025,16 +1027,20 @@ class Invoke_Request(NDRPacket):
 class Invoke_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRPacketField("pExcepInfo", EXCEPINFO(), EXCEPINFO),
         NDRIntField("pArgErr", 0),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1057,7 +1063,11 @@ register_com_interface(
 
 class CleanupNode_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrEvictedNodeNameIn", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrEvictedNodeNameIn", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
         NDRSignedIntField("nDelayIn", 0),
         NDRSignedIntField("nTimeoutIn", 0),
     ]

--- a/scapy-rpc/msrpcs/mc_iisa.py
+++ b/scapy-rpc/msrpcs/mc_iisa.py
@@ -100,7 +100,9 @@ class get_IAppHostMethod_Name_Request(NDRPacket):
 class get_IAppHostMethod_Name_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1030,21 +1032,29 @@ class wireVARIANTStr(NDRPacket):
 
 class GetMetadata_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
 class GetMetadata_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("pValue", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("pValue", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class SetMetadata_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("value", wireVARIANTStr(), wireVARIANTStr),
+        NDRFullPointerField(
+            NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(NDRPacketField("value", wireVARIANTStr(), wireVARIANTStr)),
     ]
 
 
@@ -1081,7 +1091,9 @@ class get_IAppHostElement_Name_Request(NDRPacket):
 class get_IAppHostElement_Name_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1128,21 +1140,29 @@ class get_IAppHostElement_ChildElements_Response(NDRPacket):
 
 class GetMetadata_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
 class GetMetadata_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("pValue", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("pValue", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class SetMetadata_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("value", wireVARIANTStr(), wireVARIANTStr),
+        NDRFullPointerField(
+            NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(NDRPacketField("value", wireVARIANTStr(), wireVARIANTStr)),
     ]
 
 
@@ -1165,7 +1185,9 @@ class get_IAppHostElement_Schema_Response(NDRPacket):
 
 class GetElementByName_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrSubName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrSubName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1180,7 +1202,9 @@ class GetElementByName_Response(NDRPacket):
 
 class GetPropertyByName_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrSubName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrSubName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1254,7 +1278,9 @@ class get_IAppHostProperty_Name_Request(NDRPacket):
 class get_IAppHostProperty_Name_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1267,14 +1293,18 @@ class get_IAppHostProperty_Value_Request(NDRPacket):
 class get_IAppHostProperty_Value_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pVariant", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVariant", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IAppHostProperty_Value_Request(NDRPacket):
-    fields_desc = [NDRPacketField("value", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("value", wireVARIANTStr(), wireVARIANTStr))
+    ]
 
 
 class put_IAppHostProperty_Value_Response(NDRPacket):
@@ -1296,7 +1326,9 @@ class get_IAppHostProperty_StringValue_Request(NDRPacket):
 class get_IAppHostProperty_StringValue_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrValue", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrValue", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1317,21 +1349,29 @@ class get_IAppHostProperty_Exception_Response(NDRPacket):
 
 class GetMetadata_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
 class GetMetadata_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("pValue", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("pValue", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class SetMetadata_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("value", wireVARIANTStr(), wireVARIANTStr),
+        NDRFullPointerField(
+            NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(NDRPacketField("value", wireVARIANTStr(), wireVARIANTStr)),
     ]
 
 
@@ -1390,7 +1430,11 @@ class get_IAppHostConfigLocation_Path_Request(NDRPacket):
 class get_IAppHostConfigLocation_Path_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrLocationPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrLocationPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1405,7 +1449,9 @@ class get_IAppHostConfigLocation_Count_Response(NDRPacket):
 
 
 class get_IAppHostConfigLocation_Item_Request(NDRPacket):
-    fields_desc = [NDRPacketField("cIndex", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("cIndex", wireVARIANTStr(), wireVARIANTStr))
+    ]
 
 
 class get_IAppHostConfigLocation_Item_Response(NDRPacket):
@@ -1419,7 +1465,9 @@ class get_IAppHostConfigLocation_Item_Response(NDRPacket):
 
 class AddConfigSection_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrSectionName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrSectionName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1433,7 +1481,9 @@ class AddConfigSection_Response(NDRPacket):
 
 
 class DeleteConfigSection_Request(NDRPacket):
-    fields_desc = [NDRPacketField("cIndex", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("cIndex", wireVARIANTStr(), wireVARIANTStr))
+    ]
 
 
 class DeleteConfigSection_Response(NDRPacket):
@@ -1472,7 +1522,9 @@ class get_IAppHostElementSchema_Name_Request(NDRPacket):
 class get_IAppHostElementSchema_Name_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1491,13 +1543,19 @@ class get_IAppHostElementSchema_DoesAllowUnschematizedProperties_Response(NDRPac
 
 class GetMetadata_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
 class GetMetadata_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("pValue", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("pValue", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
@@ -1594,7 +1652,9 @@ class get_IAppHostPropertySchema_Name_Request(NDRPacket):
 class get_IAppHostPropertySchema_Name_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1607,7 +1667,9 @@ class get_IAppHostPropertySchema_Type_Request(NDRPacket):
 class get_IAppHostPropertySchema_Type_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1620,7 +1682,9 @@ class get_IAppHostPropertySchema_DefaultValue_Request(NDRPacket):
 class get_IAppHostPropertySchema_DefaultValue_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pDefaultValue", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pDefaultValue", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1665,8 +1729,10 @@ class get_IAppHostPropertySchema_ValidationType_Request(NDRPacket):
 class get_IAppHostPropertySchema_ValidationType_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrValidationType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrValidationType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -1680,8 +1746,10 @@ class get_IAppHostPropertySchema_ValidationParameter_Request(NDRPacket):
 class get_IAppHostPropertySchema_ValidationParameter_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrValidationParameter", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrValidationParameter", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -1690,13 +1758,19 @@ class get_IAppHostPropertySchema_ValidationParameter_Response(NDRPacket):
 
 class GetMetadata_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
 class GetMetadata_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("pValue", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("pValue", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
@@ -1748,8 +1822,10 @@ class get_IAppHostPropertySchema_TimeSpanFormat_Request(NDRPacket):
 class get_IAppHostPropertySchema_TimeSpanFormat_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrTimeSpanFormat", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrTimeSpanFormat", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -1831,7 +1907,9 @@ class get_IAppHostConstantValue_Name_Request(NDRPacket):
 class get_IAppHostConstantValue_Name_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1865,7 +1943,9 @@ register_com_interface(
 
 class GetConfigFile_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrConfigPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrConfigPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1880,14 +1960,20 @@ class GetConfigFile_Response(NDRPacket):
 
 class GetUniqueConfigPath_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrConfigPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrConfigPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
 class GetUniqueConfigPath_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrUniquePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrUniquePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1913,7 +1999,9 @@ class GetSiteNameFromSiteId_Request(NDRPacket):
 class GetSiteNameFromSiteId_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrSiteName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrSiteName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1921,7 +2009,9 @@ class GetSiteNameFromSiteId_Response(NDRPacket):
 
 class GetSiteIdFromSiteName_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrSiteName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrSiteName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1944,15 +2034,23 @@ class GetSiteElementFromSiteId_Response(NDRPacket):
 
 class MapPath_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrSiteName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrVirtualPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrSiteName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrVirtualPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
 class MapPath_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrPhysicalPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrPhysicalPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRFullPointerField(
             NDRPacketField(
@@ -1992,7 +2090,9 @@ class get_IAppHostChildElementCollection_Count_Response(NDRPacket):
 
 
 class get_IAppHostChildElementCollection_Item_Request(NDRPacket):
-    fields_desc = [NDRPacketField("cIndex", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("cIndex", wireVARIANTStr(), wireVARIANTStr))
+    ]
 
 
 class get_IAppHostChildElementCollection_Item_Response(NDRPacket):
@@ -2032,7 +2132,9 @@ class get_IAppHostPropertyCollection_Count_Response(NDRPacket):
 
 
 class get_IAppHostPropertyCollection_Item_Request(NDRPacket):
-    fields_desc = [NDRPacketField("cIndex", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("cIndex", wireVARIANTStr(), wireVARIANTStr))
+    ]
 
 
 class get_IAppHostPropertyCollection_Item_Response(NDRPacket):
@@ -2072,7 +2174,11 @@ class get_IAppHostConfigLocationCollection_Count_Response(NDRPacket):
 
 
 class get_IAppHostConfigLocationCollection_Item_Request(NDRPacket):
-    fields_desc = [NDRPacketField("varIndex", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("varIndex", wireVARIANTStr(), wireVARIANTStr)
+        )
+    ]
 
 
 class get_IAppHostConfigLocationCollection_Item_Response(NDRPacket):
@@ -2086,7 +2192,9 @@ class get_IAppHostConfigLocationCollection_Item_Response(NDRPacket):
 
 class AddLocation_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrLocationPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrLocationPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -2100,7 +2208,9 @@ class AddLocation_Response(NDRPacket):
 
 
 class DeleteLocation_Request(NDRPacket):
-    fields_desc = [NDRPacketField("cIndex", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("cIndex", wireVARIANTStr(), wireVARIANTStr))
+    ]
 
 
 class DeleteLocation_Response(NDRPacket):
@@ -2137,7 +2247,9 @@ class get_IAppHostMethodCollection_Count_Response(NDRPacket):
 
 
 class get_IAppHostMethodCollection_Item_Request(NDRPacket):
-    fields_desc = [NDRPacketField("cIndex", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("cIndex", wireVARIANTStr(), wireVARIANTStr))
+    ]
 
 
 class get_IAppHostMethodCollection_Item_Response(NDRPacket):
@@ -2177,7 +2289,9 @@ class get_IAppHostElementSchemaCollection_Count_Response(NDRPacket):
 
 
 class get_IAppHostElementSchemaCollection_Item_Request(NDRPacket):
-    fields_desc = [NDRPacketField("cIndex", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("cIndex", wireVARIANTStr(), wireVARIANTStr))
+    ]
 
 
 class get_IAppHostElementSchemaCollection_Item_Response(NDRPacket):
@@ -2217,7 +2331,9 @@ class get_IAppHostPropertySchemaCollection_Count_Response(NDRPacket):
 
 
 class get_IAppHostPropertySchemaCollection_Item_Request(NDRPacket):
-    fields_desc = [NDRPacketField("cIndex", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("cIndex", wireVARIANTStr(), wireVARIANTStr))
+    ]
 
 
 class get_IAppHostPropertySchemaCollection_Item_Response(NDRPacket):
@@ -2257,7 +2373,9 @@ class get_IAppHostConstantValueCollection_Count_Response(NDRPacket):
 
 
 class get_IAppHostConstantValueCollection_Item_Request(NDRPacket):
-    fields_desc = [NDRPacketField("cIndex", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("cIndex", wireVARIANTStr(), wireVARIANTStr))
+    ]
 
 
 class get_IAppHostConstantValueCollection_Item_Response(NDRPacket):
@@ -2295,7 +2413,11 @@ class get_IAppHostCollectionSchema_AddElementNames_Request(NDRPacket):
 class get_IAppHostCollectionSchema_AddElementNames_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrElementName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrElementName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2303,7 +2425,9 @@ class get_IAppHostCollectionSchema_AddElementNames_Response(NDRPacket):
 
 class GetAddElementSchema_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrElementName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrElementName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -2352,13 +2476,19 @@ class get_IAppHostCollectionSchema_IsMergeAppend_Response(NDRPacket):
 
 class GetMetadata_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
 class GetMetadata_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("pValue", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("pValue", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
@@ -2414,7 +2544,9 @@ class get_IAppHostMethodSchema_Name_Request(NDRPacket):
 class get_IAppHostMethodSchema_Name_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2448,13 +2580,19 @@ class get_IAppHostMethodSchema_OutputSchema_Response(NDRPacket):
 
 class GetMetadata_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
 class GetMetadata_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("pValue", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("pValue", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
@@ -2497,7 +2635,9 @@ class get_IAppHostConfigException_FileName_Request(NDRPacket):
 class get_IAppHostConfigException_FileName_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrFileName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrFileName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2510,7 +2650,11 @@ class get_IAppHostConfigException_ConfigPath_Request(NDRPacket):
 class get_IAppHostConfigException_ConfigPath_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrConfigPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrConfigPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2523,7 +2667,9 @@ class get_IAppHostConfigException_ErrorLine_Request(NDRPacket):
 class get_IAppHostConfigException_ErrorLine_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrErrorLine", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrErrorLine", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2536,7 +2682,11 @@ class get_IAppHostConfigException_PreErrorLine_Request(NDRPacket):
 class get_IAppHostConfigException_PreErrorLine_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrPreErrorLine", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrPreErrorLine", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2549,7 +2699,11 @@ class get_IAppHostConfigException_PostErrorLine_Request(NDRPacket):
 class get_IAppHostConfigException_PostErrorLine_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrPostErrorLine", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrPostErrorLine", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2562,7 +2716,11 @@ class get_IAppHostConfigException_ErrorString_Request(NDRPacket):
 class get_IAppHostConfigException_ErrorString_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrErrorString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrErrorString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2614,7 +2772,9 @@ class get_IAppHostPropertyException_InvalidValue_Request(NDRPacket):
 class get_IAppHostPropertyException_InvalidValue_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrValue", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrValue", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2627,8 +2787,10 @@ class get_IAppHostPropertyException_ValidationFailureReason_Request(NDRPacket):
 class get_IAppHostPropertyException_ValidationFailureReason_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrValidationReason", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrValidationReason", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -2641,7 +2803,11 @@ class get_IAppHostPropertyException_ValidationFailureParameters_Request(NDRPacke
 
 class get_IAppHostPropertyException_ValidationFailureParameters_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("pParameterArray", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("pParameterArray", SAFEARRAY(), SAFEARRAY)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
@@ -2706,7 +2872,9 @@ class get_IAppHostElementCollection_Count_Response(NDRPacket):
 
 
 class get_IAppHostElementCollection_Item_Request(NDRPacket):
-    fields_desc = [NDRPacketField("cIndex", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("cIndex", wireVARIANTStr(), wireVARIANTStr))
+    ]
 
 
 class get_IAppHostElementCollection_Item_Response(NDRPacket):
@@ -2730,7 +2898,9 @@ class AddElement_Response(NDRPacket):
 
 
 class DeleteElement_Request(NDRPacket):
-    fields_desc = [NDRPacketField("cIndex", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("cIndex", wireVARIANTStr(), wireVARIANTStr))
+    ]
 
 
 class DeleteElement_Response(NDRPacket):
@@ -2747,7 +2917,9 @@ class Clear_Response(NDRPacket):
 
 class CreateNewElement_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrElementName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrElementName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -2807,7 +2979,9 @@ class get_IAppHostSectionDefinition_Name_Request(NDRPacket):
 class get_IAppHostSectionDefinition_Name_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2820,14 +2994,20 @@ class get_IAppHostSectionDefinition_Type_Request(NDRPacket):
 class get_IAppHostSectionDefinition_Type_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IAppHostSectionDefinition_Type_Request(NDRPacket):
-    fields_desc = [NDRPacketField("bstrType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("bstrType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IAppHostSectionDefinition_Type_Response(NDRPacket):
@@ -2841,8 +3021,10 @@ class get_IAppHostSectionDefinition_OverrideModeDefault_Request(NDRPacket):
 class get_IAppHostSectionDefinition_OverrideModeDefault_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrOverrideModeDefault", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrOverrideModeDefault", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -2851,8 +3033,10 @@ class get_IAppHostSectionDefinition_OverrideModeDefault_Response(NDRPacket):
 
 class put_IAppHostSectionDefinition_OverrideModeDefault_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField(
-            "bstrOverrideModeDefault", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrOverrideModeDefault", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         )
     ]
 
@@ -2868,8 +3052,10 @@ class get_IAppHostSectionDefinition_AllowDefinition_Request(NDRPacket):
 class get_IAppHostSectionDefinition_AllowDefinition_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrAllowDefinition", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrAllowDefinition", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -2878,7 +3064,11 @@ class get_IAppHostSectionDefinition_AllowDefinition_Response(NDRPacket):
 
 class put_IAppHostSectionDefinition_AllowDefinition_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrAllowDefinition", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrAllowDefinition", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        )
     ]
 
 
@@ -2893,7 +3083,11 @@ class get_IAppHostSectionDefinition_AllowLocation_Request(NDRPacket):
 class get_IAppHostSectionDefinition_AllowLocation_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrAllowLocation", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrAllowLocation", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2901,7 +3095,9 @@ class get_IAppHostSectionDefinition_AllowLocation_Response(NDRPacket):
 
 class put_IAppHostSectionDefinition_AllowLocation_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrAllowLocation", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrAllowLocation", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -2965,7 +3161,11 @@ class get_IAppHostSectionDefinitionCollection_Count_Response(NDRPacket):
 
 
 class get_IAppHostSectionDefinitionCollection_Item_Request(NDRPacket):
-    fields_desc = [NDRPacketField("varIndex", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("varIndex", wireVARIANTStr(), wireVARIANTStr)
+        )
+    ]
 
 
 class get_IAppHostSectionDefinitionCollection_Item_Response(NDRPacket):
@@ -2979,7 +3179,9 @@ class get_IAppHostSectionDefinitionCollection_Item_Response(NDRPacket):
 
 class AddSection_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrSectionName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrSectionName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -2993,7 +3195,11 @@ class AddSection_Response(NDRPacket):
 
 
 class DeleteSection_Request(NDRPacket):
-    fields_desc = [NDRPacketField("varIndex", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("varIndex", wireVARIANTStr(), wireVARIANTStr)
+        )
+    ]
 
 
 class DeleteSection_Response(NDRPacket):
@@ -3030,7 +3236,11 @@ class get_IAppHostSectionGroup_Count_Response(NDRPacket):
 
 
 class get_IAppHostSectionGroup_Item_Request(NDRPacket):
-    fields_desc = [NDRPacketField("varIndex", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("varIndex", wireVARIANTStr(), wireVARIANTStr)
+        )
+    ]
 
 
 class get_IAppHostSectionGroup_Item_Response(NDRPacket):
@@ -3057,7 +3267,11 @@ class get_IAppHostSectionGroup_Sections_Response(NDRPacket):
 
 class AddSectionGroup_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrSectionGroupName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrSectionGroupName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        )
     ]
 
 
@@ -3071,7 +3285,11 @@ class AddSectionGroup_Response(NDRPacket):
 
 
 class DeleteSectionGroup_Request(NDRPacket):
-    fields_desc = [NDRPacketField("varIndex", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("varIndex", wireVARIANTStr(), wireVARIANTStr)
+        )
+    ]
 
 
 class DeleteSectionGroup_Response(NDRPacket):
@@ -3085,7 +3303,9 @@ class get_IAppHostSectionGroup_Name_Request(NDRPacket):
 class get_IAppHostSectionGroup_Name_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -3098,14 +3318,20 @@ class get_IAppHostSectionGroup_Type_Request(NDRPacket):
 class get_IAppHostSectionGroup_Type_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IAppHostSectionGroup_Type_Request(NDRPacket):
-    fields_desc = [NDRPacketField("bstrType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("bstrType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IAppHostSectionGroup_Type_Response(NDRPacket):
@@ -3151,7 +3377,11 @@ class get_IAppHostConfigFile_ConfigPath_Request(NDRPacket):
 class get_IAppHostConfigFile_ConfigPath_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrConfigPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrConfigPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -3164,7 +3394,9 @@ class get_IAppHostConfigFile_FilePath_Request(NDRPacket):
 class get_IAppHostConfigFile_FilePath_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrFilePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrFilePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -3185,8 +3417,12 @@ class get_IAppHostConfigFile_Locations_Response(NDRPacket):
 
 class GetAdminSection_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrSectionName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrSectionName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -3201,21 +3437,29 @@ class GetAdminSection_Response(NDRPacket):
 
 class GetMetadata_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
 class GetMetadata_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("pValue", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("pValue", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class SetMetadata_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("value", wireVARIANTStr(), wireVARIANTStr),
+        NDRFullPointerField(
+            NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(NDRPacketField("value", wireVARIANTStr(), wireVARIANTStr)),
     ]
 
 
@@ -3277,9 +3521,13 @@ register_com_interface(
 
 class MapPath_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrConfigPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField(
-            "bstrMappedPhysicalPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField("bstrConfigPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrMappedPhysicalPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         ),
     ]
 
@@ -3287,8 +3535,10 @@ class MapPath_Request(NDRPacket):
 class MapPath_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrNewPhysicalPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrNewPhysicalPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -3309,8 +3559,12 @@ register_com_interface(
 
 class OnSectionChanges_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrSectionName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrConfigPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrSectionName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrConfigPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -3332,8 +3586,12 @@ register_com_interface(
 
 class GetAdminSection_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrSectionName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrSectionName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -3348,21 +3606,29 @@ class GetAdminSection_Response(NDRPacket):
 
 class GetMetadata_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
 class GetMetadata_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("pValue", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("pValue", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class SetMetadata_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("value", wireVARIANTStr(), wireVARIANTStr),
+        NDRFullPointerField(
+            NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(NDRPacketField("value", wireVARIANTStr(), wireVARIANTStr)),
     ]
 
 
@@ -3416,7 +3682,11 @@ class get_IAppHostWritableAdminManager_CommitPath_Request(NDRPacket):
 class get_IAppHostWritableAdminManager_CommitPath_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrCommitPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrCommitPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -3424,7 +3694,9 @@ class get_IAppHostWritableAdminManager_CommitPath_Response(NDRPacket):
 
 class put_IAppHostWritableAdminManager_CommitPath_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrCommitPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrCommitPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 

--- a/scapy-rpc/msrpcs/ms_adtg.py
+++ b/scapy-rpc/msrpcs/ms_adtg.py
@@ -80,8 +80,12 @@ class MInterfacePointer(NDRPacket):
 
 class Query_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrConnection", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrQuery", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrConnection", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrQuery", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("lMarshalOptions", 0),
     ]
 
@@ -97,7 +101,9 @@ class Query_Response(NDRPacket):
 
 class SubmitChanges_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrConnection", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrConnection", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRPacketField("pRecordset", MInterfacePointer(), MInterfacePointer),
     ]
 
@@ -113,7 +119,9 @@ class ConvertToString_Request(NDRPacket):
 class ConvertToString_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrInline", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrInline", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -957,7 +965,11 @@ class wireVARIANTStr(NDRPacket):
 
 
 class CreateRecordSet_Request(NDRPacket):
-    fields_desc = [NDRPacketField("varColumnInfos", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("varColumnInfos", wireVARIANTStr(), wireVARIANTStr)
+        )
+    ]
 
 
 class CreateRecordSet_Response(NDRPacket):
@@ -987,15 +999,27 @@ register_dcerpc_interface(
 
 class Execute21_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("ConnectionString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("HandlerString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("QueryString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("ConnectionString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("HandlerString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("QueryString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("lMarshalOptions", 0),
-        NDRPacketField("Properties", wireVARIANTStr(), wireVARIANTStr),
-        NDRPacketField("TableId", wireVARIANTStr(), wireVARIANTStr),
+        NDRFullPointerField(
+            NDRPacketField("Properties", wireVARIANTStr(), wireVARIANTStr)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("TableId", wireVARIANTStr(), wireVARIANTStr)
+        ),
         NDRSignedIntField("lExecuteOptions", 0),
         NDRFullPointerField(
-            NDRPacketField("pParameters", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pParameters", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
     ]
 
@@ -1003,7 +1027,9 @@ class Execute21_Request(NDRPacket):
 class Execute21_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pParameters", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pParameters", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRFullPointerField(
             NDRPacketField("ppRecordset", MInterfacePointer(), MInterfacePointer)
@@ -1014,14 +1040,20 @@ class Execute21_Response(NDRPacket):
 
 class Synchronize21_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("ConnectionString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("HandlerString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("ConnectionString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("HandlerString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("lSynchronizeOptions", 0),
         NDRFullPointerField(
             NDRPacketField("ppRecordset", MInterfacePointer(), MInterfacePointer)
         ),
         NDRFullPointerField(
-            NDRPacketField("pStatusArray", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pStatusArray", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
     ]
 
@@ -1032,10 +1064,14 @@ class Synchronize21_Response(NDRPacket):
             NDRPacketField("ppRecordset", MInterfacePointer(), MInterfacePointer)
         ),
         NDRFullPointerField(
-            NDRPacketField("pStatusArray", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pStatusArray", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRFullPointerField(
-            NDRPacketField("pResult", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pResult", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1061,19 +1097,33 @@ register_dcerpc_interface(
 
 class Execute_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("ConnectionString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("HandlerString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("QueryString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("ConnectionString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("HandlerString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("QueryString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("lMarshalOptions", 0),
-        NDRPacketField("Properties", wireVARIANTStr(), wireVARIANTStr),
-        NDRPacketField("TableId", wireVARIANTStr(), wireVARIANTStr),
+        NDRFullPointerField(
+            NDRPacketField("Properties", wireVARIANTStr(), wireVARIANTStr)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("TableId", wireVARIANTStr(), wireVARIANTStr)
+        ),
         NDRSignedIntField("lExecuteOptions", 0),
         NDRFullPointerField(
-            NDRPacketField("pParameters", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pParameters", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRSignedIntField("lcid", 0),
         NDRFullPointerField(
-            NDRPacketField("pInformation", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pInformation", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
     ]
 
@@ -1081,10 +1131,14 @@ class Execute_Request(NDRPacket):
 class Execute_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pParameters", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pParameters", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRFullPointerField(
-            NDRPacketField("pInformation", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pInformation", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRFullPointerField(
             NDRPacketField("ppRecordset", MInterfacePointer(), MInterfacePointer)
@@ -1095,18 +1149,26 @@ class Execute_Response(NDRPacket):
 
 class Synchronize_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("ConnectionString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("HandlerString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("ConnectionString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("HandlerString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("lSynchronizeOptions", 0),
         NDRFullPointerField(
             NDRPacketField("ppRecordset", MInterfacePointer(), MInterfacePointer)
         ),
         NDRFullPointerField(
-            NDRPacketField("pStatusArray", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pStatusArray", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRSignedIntField("lcid", 0),
         NDRFullPointerField(
-            NDRPacketField("pInformation", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pInformation", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
     ]
 
@@ -1117,13 +1179,19 @@ class Synchronize_Response(NDRPacket):
             NDRPacketField("ppRecordset", MInterfacePointer(), MInterfacePointer)
         ),
         NDRFullPointerField(
-            NDRPacketField("pStatusArray", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pStatusArray", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRFullPointerField(
-            NDRPacketField("pInformation", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pInformation", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRFullPointerField(
-            NDRPacketField("pResult", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pResult", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRIntField("status", 0),
     ]

--- a/scapy-rpc/msrpcs/ms_adts_claims.py
+++ b/scapy-rpc/msrpcs/ms_adts_claims.py
@@ -29,6 +29,7 @@ from scapy.layers.dcerpc import (
     NDRIntField,
     NDRLongField,
     NDRPacketField,
+    NDRRefEmbPointerField,
     NDRShortField,
     NDRSignedLongField,
     NDRUnionField,
@@ -290,7 +291,7 @@ class CLAIMS_ARRAY(NDRPacket):
     fields_desc = [
         NDRInt3264EnumField("usClaimsSourceType", 0, CLAIMS_SOURCE_TYPE),
         NDRIntField("ulClaimsCount", None, size_of="ClaimEntries"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "ClaimEntries", [], PCLAIM_ENTRY, size_is=lambda pkt: pkt.ulClaimsCount
             )
@@ -303,7 +304,7 @@ class PCLAIMS_ARRAY(NDRPacket):
     fields_desc = [
         NDRInt3264EnumField("usClaimsSourceType", 0, CLAIMS_SOURCE_TYPE),
         NDRIntField("ulClaimsCount", None, size_of="ClaimEntries"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "ClaimEntries", [], PCLAIM_ENTRY, size_is=lambda pkt: pkt.ulClaimsCount
             )
@@ -315,7 +316,7 @@ class CLAIMS_SET(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
         NDRIntField("ulClaimsArrayCount", None, size_of="ClaimsArrays"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "ClaimsArrays",
                 [],
@@ -337,7 +338,7 @@ class PCLAIMS_SET(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
         NDRIntField("ulClaimsArrayCount", None, size_of="ClaimsArrays"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "ClaimsArrays",
                 [],

--- a/scapy-rpc/msrpcs/ms_cmrp_clusapi2.py
+++ b/scapy-rpc/msrpcs/ms_cmrp_clusapi2.py
@@ -404,12 +404,8 @@ class ApiCreateKey_Request(NDRPacket):
         NDRConfVarStrNullFieldUtf16("lpSubKey", ""),
         NDRIntField("dwOptions", 0),
         NDRIntField("samDesired", 0),
-        NDRFullPointerField(
-            NDRPacketField(
-                "lpSecurityAttributes",
-                PRPC_SECURITY_ATTRIBUTES(),
-                PRPC_SECURITY_ATTRIBUTES,
-            )
+        NDRPacketField(
+            "lpSecurityAttributes", PRPC_SECURITY_ATTRIBUTES(), PRPC_SECURITY_ATTRIBUTES
         ),
     ]
 

--- a/scapy-rpc/msrpcs/ms_cmrp_clusapi3.py
+++ b/scapy-rpc/msrpcs/ms_cmrp_clusapi3.py
@@ -408,12 +408,8 @@ class ApiCreateKey_Request(NDRPacket):
         NDRConfVarStrNullFieldUtf16("lpSubKey", ""),
         NDRIntField("dwOptions", 0),
         NDRIntField("samDesired", 0),
-        NDRFullPointerField(
-            NDRPacketField(
-                "lpSecurityAttributes",
-                PRPC_SECURITY_ATTRIBUTES(),
-                PRPC_SECURITY_ATTRIBUTES,
-            )
+        NDRPacketField(
+            "lpSecurityAttributes", PRPC_SECURITY_ATTRIBUTES(), PRPC_SECURITY_ATTRIBUTES
         ),
     ]
 
@@ -1896,12 +1892,10 @@ class PCLUSTER_CREATE_GROUP_INFO_RPC(NDRPacket):
 class ApiCreateGroupEx_Request(NDRPacket):
     fields_desc = [
         NDRConfVarStrNullFieldUtf16("lpszGroupName", ""),
-        NDRFullPointerField(
-            NDRPacketField(
-                "pGroupInfo",
-                PCLUSTER_CREATE_GROUP_INFO_RPC(),
-                PCLUSTER_CREATE_GROUP_INFO_RPC,
-            )
+        NDRPacketField(
+            "pGroupInfo",
+            PCLUSTER_CREATE_GROUP_INFO_RPC(),
+            PCLUSTER_CREATE_GROUP_INFO_RPC,
         ),
     ]
 
@@ -2068,7 +2062,6 @@ class ApiGetNotifyV2_Response(NDRPacket):
             [],
             PNOTIFICATION_RPC,
             size_is=lambda pkt: pkt.dwNumNotifications,
-            ptr_pack=True,
         ),
         NDRIntField("dwNumNotifications", None, size_of="Notifications"),
         NDRIntField("status", 0),
@@ -2249,7 +2242,6 @@ class ApiGetNotifyAsync_Response(NDRPacket):
             [],
             PNOTIFICATION_DATA_ASYNC_RPC,
             size_is=lambda pkt: pkt.dwNumNotifications,
-            ptr_pack=True,
         ),
         NDRIntField("dwNumNotifications", None, size_of="Notifications"),
         NDRIntField("status", 0),

--- a/scapy-rpc/msrpcs/ms_coma.py
+++ b/scapy-rpc/msrpcs/ms_coma.py
@@ -738,12 +738,22 @@ class FLAGGED_WORD_BLOB(NDRPacket):
 class CreateConfiguration_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("ConglomerationIdentifier", GUID(), GUID),
-        NDRPacketField("bstrConfigurationName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrConfigurationName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
         NDRIntField("dwStartType", 0),
         NDRIntField("dwErrorControl", 0),
-        NDRPacketField("bstrDependencies", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrRunAs", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrPassword", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrDependencies", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrRunAs", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrPassword", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedShortField("bDesktopOk", 0),
     ]
 
@@ -915,7 +925,11 @@ class GetEventClassesForIID2_Response(NDRPacket):
 
 
 class IsSafeToDelete_Request(NDRPacket):
-    fields_desc = [NDRPacketField("bstrFile", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("bstrFile", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class IsSafeToDelete_Response(NDRPacket):
@@ -1197,7 +1211,11 @@ class GetContainerIDFromProcessID_Request(NDRPacket):
 class GetContainerIDFromProcessID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrContainerID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrContainerID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]

--- a/scapy-rpc/msrpcs/ms_comev.py
+++ b/scapy-rpc/msrpcs/ms_comev.py
@@ -1024,12 +1024,14 @@ class Invoke_Request(NDRPacket):
         NDRConfFieldListField(
             "rgVarRefIdx", [], NDRIntField("", 0), size_is=lambda pkt: pkt.cVarRef
         ),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
     ]
 
@@ -1037,16 +1039,20 @@ class Invoke_Request(NDRPacket):
 class Invoke_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRPacketField("pExcepInfo", EXCEPINFO(), EXCEPINFO),
         NDRIntField("pArgErr", 0),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1081,12 +1087,20 @@ class get_IEventObjectCollection__NewEnum_Response(NDRPacket):
 
 
 class get_IEventObjectCollection_Item_Request(NDRPacket):
-    fields_desc = [NDRPacketField("objectID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("objectID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class get_IEventObjectCollection_Item_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("pItem", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("pItem", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
@@ -1114,8 +1128,14 @@ class get_IEventObjectCollection_Count_Response(NDRPacket):
 
 class Add_Request(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("item", wireVARIANTStr(), wireVARIANTStr)),
-        NDRPacketField("objectID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("item", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
+        NDRFullPointerField(
+            NDRPacketField("objectID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -1124,7 +1144,11 @@ class Add_Response(NDRPacket):
 
 
 class Remove_Request(NDRPacket):
-    fields_desc = [NDRPacketField("objectID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("objectID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class Remove_Response(NDRPacket):
@@ -1166,8 +1190,12 @@ register_com_interface(
 
 class Query_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("progID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("queryCriteria", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("progID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("queryCriteria", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -1183,7 +1211,9 @@ class Query_Response(NDRPacket):
 
 class Store_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("ProgID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("ProgID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRPacketField("pInterface", MInterfacePointer(), MInterfacePointer),
     ]
 
@@ -1194,8 +1224,12 @@ class Store_Response(NDRPacket):
 
 class Remove_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("progID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("queryCriteria", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("progID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("queryCriteria", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -1210,7 +1244,11 @@ class get_IEventSystem_EventObjectChangeEventClassID_Request(NDRPacket):
 class get_IEventSystem_EventObjectChangeEventClassID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrEventClassID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrEventClassID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1218,8 +1256,12 @@ class get_IEventSystem_EventObjectChangeEventClassID_Response(NDRPacket):
 
 class QueryS_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("progID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("queryCriteria", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("progID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("queryCriteria", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -1234,8 +1276,12 @@ class QueryS_Response(NDRPacket):
 
 class RemoveS_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("progID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("queryCriteria", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("progID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("queryCriteria", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -1274,7 +1320,11 @@ class get_IEventClass_EventClassID_Request(NDRPacket):
 class get_IEventClass_EventClassID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrEventClassID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrEventClassID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1282,7 +1332,9 @@ class get_IEventClass_EventClassID_Response(NDRPacket):
 
 class put_IEventClass_EventClassID_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrEventClassID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrEventClassID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1297,8 +1349,10 @@ class get_IEventClass_EventClassName_Request(NDRPacket):
 class get_IEventClass_EventClassName_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrEventClassName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrEventClassName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -1307,7 +1361,9 @@ class get_IEventClass_EventClassName_Response(NDRPacket):
 
 class put_IEventClass_EventClassName_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrEventClassName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrEventClassName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1322,7 +1378,9 @@ class get_IEventClass_OwnerSID_Request(NDRPacket):
 class get_IEventClass_OwnerSID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrOwnerSID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrOwnerSID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1330,7 +1388,9 @@ class get_IEventClass_OwnerSID_Response(NDRPacket):
 
 class put_IEventClass_OwnerSID_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrOwnerSID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrOwnerSID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1345,8 +1405,10 @@ class get_IEventClass_FiringInterfaceID_Request(NDRPacket):
 class get_IEventClass_FiringInterfaceID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrFiringInterfaceID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrFiringInterfaceID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -1355,7 +1417,11 @@ class get_IEventClass_FiringInterfaceID_Response(NDRPacket):
 
 class put_IEventClass_FiringInterfaceID_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrFiringInterfaceID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrFiringInterfaceID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        )
     ]
 
 
@@ -1370,7 +1436,11 @@ class get_IEventClass_Description_Request(NDRPacket):
 class get_IEventClass_Description_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrDescription", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrDescription", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1378,7 +1448,9 @@ class get_IEventClass_Description_Response(NDRPacket):
 
 class put_IEventClass_Description_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrDescription", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrDescription", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1393,7 +1465,9 @@ class get_IEventClass_TypeLib_Request(NDRPacket):
 class get_IEventClass_TypeLib_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrTypeLib", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrTypeLib", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1401,7 +1475,9 @@ class get_IEventClass_TypeLib_Response(NDRPacket):
 
 class put_IEventClass_TypeLib_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrTypeLib", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrTypeLib", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1463,7 +1539,11 @@ class get_IEventClass2_PublisherID_Request(NDRPacket):
 class get_IEventClass2_PublisherID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrPublisherID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrPublisherID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1471,7 +1551,9 @@ class get_IEventClass2_PublisherID_Response(NDRPacket):
 
 class put_IEventClass2_PublisherID_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrPublisherID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrPublisherID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1486,7 +1568,11 @@ class get_IEventClass2_MultiInterfacePublisherFilterCLSID_Request(NDRPacket):
 class get_IEventClass2_MultiInterfacePublisherFilterCLSID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrPubFilCLSID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrPubFilCLSID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1494,7 +1580,9 @@ class get_IEventClass2_MultiInterfacePublisherFilterCLSID_Response(NDRPacket):
 
 class put_IEventClass2_MultiInterfacePublisherFilterCLSID_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrPubFilCLSID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrPubFilCLSID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1684,8 +1772,10 @@ class get_IEventSubscription_SubscriptionID_Request(NDRPacket):
 class get_IEventSubscription_SubscriptionID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrSubscriptionID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrSubscriptionID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -1694,7 +1784,9 @@ class get_IEventSubscription_SubscriptionID_Response(NDRPacket):
 
 class put_IEventSubscription_SubscriptionID_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrSubscriptionID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrSubscriptionID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1709,8 +1801,10 @@ class get_IEventSubscription_SubscriptionName_Request(NDRPacket):
 class get_IEventSubscription_SubscriptionName_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrSubscriptionName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrSubscriptionName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -1719,7 +1813,11 @@ class get_IEventSubscription_SubscriptionName_Response(NDRPacket):
 
 class put_IEventSubscription_SubscriptionName_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrSubscriptionName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrSubscriptionName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        )
     ]
 
 
@@ -1734,7 +1832,11 @@ class get_IEventSubscription_PublisherID_Request(NDRPacket):
 class get_IEventSubscription_PublisherID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrPublisherID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrPublisherID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1742,7 +1844,9 @@ class get_IEventSubscription_PublisherID_Response(NDRPacket):
 
 class put_IEventSubscription_PublisherID_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrPublisherID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrPublisherID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1757,7 +1861,11 @@ class get_IEventSubscription_EventClassID_Request(NDRPacket):
 class get_IEventSubscription_EventClassID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrEventClassID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrEventClassID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1765,7 +1873,9 @@ class get_IEventSubscription_EventClassID_Response(NDRPacket):
 
 class put_IEventSubscription_EventClassID_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrEventClassID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrEventClassID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1780,7 +1890,11 @@ class get_IEventSubscription_MethodName_Request(NDRPacket):
 class get_IEventSubscription_MethodName_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrMethodName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrMethodName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1788,7 +1902,9 @@ class get_IEventSubscription_MethodName_Response(NDRPacket):
 
 class put_IEventSubscription_MethodName_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrMethodName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrMethodName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1803,8 +1919,10 @@ class get_IEventSubscription_SubscriberCLSID_Request(NDRPacket):
 class get_IEventSubscription_SubscriberCLSID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrSubscriberCLSID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrSubscriberCLSID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -1813,7 +1931,11 @@ class get_IEventSubscription_SubscriberCLSID_Response(NDRPacket):
 
 class put_IEventSubscription_SubscriberCLSID_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrSubscriberCLSID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrSubscriberCLSID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        )
     ]
 
 
@@ -1869,7 +1991,9 @@ class get_IEventSubscription_OwnerSID_Request(NDRPacket):
 class get_IEventSubscription_OwnerSID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrOwnerSID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrOwnerSID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1877,7 +2001,9 @@ class get_IEventSubscription_OwnerSID_Response(NDRPacket):
 
 class put_IEventSubscription_OwnerSID_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrOwnerSID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrOwnerSID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1908,7 +2034,11 @@ class get_IEventSubscription_Description_Request(NDRPacket):
 class get_IEventSubscription_Description_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrDescription", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrDescription", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1916,7 +2046,9 @@ class get_IEventSubscription_Description_Response(NDRPacket):
 
 class put_IEventSubscription_Description_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrDescription", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrDescription", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1931,7 +2063,11 @@ class get_IEventSubscription_MachineName_Request(NDRPacket):
 class get_IEventSubscription_MachineName_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrMachineName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrMachineName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1939,7 +2075,9 @@ class get_IEventSubscription_MachineName_Response(NDRPacket):
 
 class put_IEventSubscription_MachineName_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrMachineName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrMachineName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1949,14 +2087,18 @@ class put_IEventSubscription_MachineName_Response(NDRPacket):
 
 class GetPublisherProperty_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrPropertyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrPropertyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
 class GetPublisherProperty_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("propertyValue", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("propertyValue", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1964,9 +2106,13 @@ class GetPublisherProperty_Response(NDRPacket):
 
 class PutPublisherProperty_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrPropertyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
         NDRFullPointerField(
-            NDRPacketField("propertyValue", wireVARIANTStr(), wireVARIANTStr)
+            NDRPacketField("bstrPropertyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("propertyValue", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
     ]
 
@@ -1977,7 +2123,9 @@ class PutPublisherProperty_Response(NDRPacket):
 
 class RemovePublisherProperty_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrPropertyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrPropertyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -2000,14 +2148,18 @@ class GetPublisherPropertyCollection_Response(NDRPacket):
 
 class GetSubscriberProperty_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrPropertyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrPropertyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
 class GetSubscriberProperty_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("propertyValue", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("propertyValue", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2015,9 +2167,13 @@ class GetSubscriberProperty_Response(NDRPacket):
 
 class PutSubscriberProperty_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrPropertyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
         NDRFullPointerField(
-            NDRPacketField("propertyValue", wireVARIANTStr(), wireVARIANTStr)
+            NDRPacketField("bstrPropertyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("propertyValue", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
     ]
 
@@ -2028,7 +2184,9 @@ class PutSubscriberProperty_Response(NDRPacket):
 
 class RemoveSubscriberProperty_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrPropertyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrPropertyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -2056,7 +2214,11 @@ class get_IEventSubscription_InterfaceID_Request(NDRPacket):
 class get_IEventSubscription_InterfaceID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrInterfaceID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrInterfaceID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2064,7 +2226,9 @@ class get_IEventSubscription_InterfaceID_Response(NDRPacket):
 
 class put_IEventSubscription_InterfaceID_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrInterfaceID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrInterfaceID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -2207,8 +2371,10 @@ class get_IEventSubscription2_FilterCriteria_Request(NDRPacket):
 class get_IEventSubscription2_FilterCriteria_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrFilterCriteria", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrFilterCriteria", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -2217,7 +2383,9 @@ class get_IEventSubscription2_FilterCriteria_Response(NDRPacket):
 
 class put_IEventSubscription2_FilterCriteria_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrFilterCriteria", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrFilterCriteria", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -2232,7 +2400,9 @@ class get_IEventSubscription2_SubscriberMoniker_Request(NDRPacket):
 class get_IEventSubscription2_SubscriberMoniker_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrMoniker", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrMoniker", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2240,7 +2410,9 @@ class get_IEventSubscription2_SubscriberMoniker_Response(NDRPacket):
 
 class put_IEventSubscription2_SubscriberMoniker_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrMoniker", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrMoniker", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -2399,8 +2571,10 @@ class get_IEventClass3_EventClassPartitionID_Request(NDRPacket):
 class get_IEventClass3_EventClassPartitionID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrEventClassPartitionID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrEventClassPartitionID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -2409,8 +2583,10 @@ class get_IEventClass3_EventClassPartitionID_Response(NDRPacket):
 
 class put_IEventClass3_EventClassPartitionID_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField(
-            "bstrEventClassPartitionID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrEventClassPartitionID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         )
     ]
 
@@ -2426,8 +2602,12 @@ class get_IEventClass3_EventClassApplicationID_Request(NDRPacket):
 class get_IEventClass3_EventClassApplicationID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrEventClassApplicationID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrEventClassApplicationID",
+                    FLAGGED_WORD_BLOB(),
+                    FLAGGED_WORD_BLOB,
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -2436,8 +2616,10 @@ class get_IEventClass3_EventClassApplicationID_Response(NDRPacket):
 
 class put_IEventClass3_EventClassApplicationID_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField(
-            "bstrEventClassApplicationID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrEventClassApplicationID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         )
     ]
 
@@ -2546,8 +2728,10 @@ class get_IEventSubscription3_EventClassPartitionID_Request(NDRPacket):
 class get_IEventSubscription3_EventClassPartitionID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrEventClassPartitionID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrEventClassPartitionID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -2556,8 +2740,10 @@ class get_IEventSubscription3_EventClassPartitionID_Response(NDRPacket):
 
 class put_IEventSubscription3_EventClassPartitionID_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField(
-            "bstrEventClassPartitionID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrEventClassPartitionID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         )
     ]
 
@@ -2573,8 +2759,12 @@ class get_IEventSubscription3_EventClassApplicationID_Request(NDRPacket):
 class get_IEventSubscription3_EventClassApplicationID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrEventClassApplicationID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrEventClassApplicationID",
+                    FLAGGED_WORD_BLOB(),
+                    FLAGGED_WORD_BLOB,
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -2583,8 +2773,10 @@ class get_IEventSubscription3_EventClassApplicationID_Response(NDRPacket):
 
 class put_IEventSubscription3_EventClassApplicationID_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField(
-            "bstrEventClassApplicationID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrEventClassApplicationID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         )
     ]
 
@@ -2600,8 +2792,10 @@ class get_IEventSubscription3_SubscriberPartitionID_Request(NDRPacket):
 class get_IEventSubscription3_SubscriberPartitionID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrSubscriberPartitionID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrSubscriberPartitionID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -2610,8 +2804,10 @@ class get_IEventSubscription3_SubscriberPartitionID_Response(NDRPacket):
 
 class put_IEventSubscription3_SubscriberPartitionID_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField(
-            "bstrSubscriberPartitionID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrSubscriberPartitionID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         )
     ]
 
@@ -2627,8 +2823,12 @@ class get_IEventSubscription3_SubscriberApplicationID_Request(NDRPacket):
 class get_IEventSubscription3_SubscriberApplicationID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrSubscriberApplicationID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrSubscriberApplicationID",
+                    FLAGGED_WORD_BLOB(),
+                    FLAGGED_WORD_BLOB,
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -2637,8 +2837,10 @@ class get_IEventSubscription3_SubscriberApplicationID_Response(NDRPacket):
 
 class put_IEventSubscription3_SubscriberApplicationID_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField(
-            "bstrSubscriberApplicationID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrSubscriberApplicationID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         )
     ]
 

--- a/scapy-rpc/msrpcs/ms_comt.py
+++ b/scapy-rpc/msrpcs/ms_comt.py
@@ -1140,12 +1140,14 @@ class Invoke_Request(NDRPacket):
         NDRConfFieldListField(
             "rgVarRefIdx", [], NDRIntField("", 0), size_is=lambda pkt: pkt.cVarRef
         ),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
     ]
 
@@ -1153,16 +1155,20 @@ class Invoke_Request(NDRPacket):
 class Invoke_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRPacketField("pExcepInfo", EXCEPINFO(), EXCEPINFO),
         NDRIntField("pArgErr", 0),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1193,8 +1199,12 @@ class IsSupported_Response(NDRPacket):
 
 class DumpProcess_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrContainerID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrDirectory", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrContainerID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrDirectory", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRIntField("dwMaxFiles", 0),
     ]
 
@@ -1202,7 +1212,9 @@ class DumpProcess_Request(NDRPacket):
 class DumpProcess_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrDumpFile", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrDumpFile", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]

--- a/scapy-rpc/msrpcs/ms_csvp.py
+++ b/scapy-rpc/msrpcs/ms_csvp.py
@@ -404,7 +404,9 @@ class GenerateClusterLog_Request(NDRPacket):
 class GenerateClusterLog_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("LogFilePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("LogFilePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -420,7 +422,9 @@ class GenerateClusterHealthLog_Request(NDRPacket):
 class GenerateClusterHealthLog_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("LogFilePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("LogFilePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -436,7 +440,9 @@ class GenerateClusterSetLog_Request(NDRPacket):
 class GenerateClusterSetLog_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("LogFilePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("LogFilePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -453,7 +459,9 @@ class GenerateClusterNetworkhLog_Request(NDRPacket):
 class GenerateClusterNetworkhLog_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("LogFilePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("LogFilePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -461,9 +469,13 @@ class GenerateClusterNetworkhLog_Response(NDRPacket):
 
 class ExportClusterPerformanceHistory_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("Pattern", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
         NDRFullPointerField(
-            NDRPacketField("StreamName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRPacketField("Pattern", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("StreamName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRInt3264EnumField("flags", 0, ClusterLogExFlag),
     ]
@@ -472,7 +484,9 @@ class ExportClusterPerformanceHistory_Request(NDRPacket):
 class ExportClusterPerformanceHistory_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("LogFilePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("LogFilePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -488,7 +502,9 @@ class GenerateNetftLog_Request(NDRPacket):
 class GenerateNetftLog_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("LogFilePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("LogFilePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -536,7 +552,9 @@ class GenerateLogEx_Request(NDRPacket):
 class GenerateLogEx_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("LogFilePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("LogFilePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -557,7 +575,9 @@ class GetLogFilePath_Request(NDRPacket):
 class GetLogFilePath_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("LogFilePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("LogFilePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -600,11 +620,17 @@ class GenerateLogEx2_Request(NDRPacket):
 class GenerateLogEx2_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("LongFilePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("LongFilePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRFullPointerField(
-            NDRPacketField(
-                "SemicolonSeperatedLogFilesPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "SemicolonSeperatedLogFilesPath",
+                    FLAGGED_WORD_BLOB(),
+                    FLAGGED_WORD_BLOB,
+                )
             )
         ),
         NDRIntField("status", 0),

--- a/scapy-rpc/msrpcs/ms_dfsrh.py
+++ b/scapy-rpc/msrpcs/ms_dfsrh.py
@@ -921,11 +921,19 @@ class SAFEARRAY(NDRPacket):
 
 class CreateObject_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("domainControllerName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("distinguishedName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField(
+                "domainControllerName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
+        NDRFullPointerField(
+            NDRPacketField("distinguishedName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRFullPointerField(NDRPacketField("attributes", SAFEARRAY(), SAFEARRAY)),
-        NDRPacketField(
-            "verifyNameDomainControllerName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField(
+                "verifyNameDomainControllerName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         ),
     ]
 
@@ -936,8 +944,14 @@ class CreateObject_Response(NDRPacket):
 
 class DeleteObject_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("domainControllerName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("distinguishedName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField(
+                "domainControllerName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
+        NDRFullPointerField(
+            NDRPacketField("distinguishedName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -947,8 +961,14 @@ class DeleteObject_Response(NDRPacket):
 
 class ModifyObject_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("domainControllerName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("distinguishedName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField(
+                "domainControllerName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
+        NDRFullPointerField(
+            NDRPacketField("distinguishedName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRFullPointerField(NDRPacketField("attributes", SAFEARRAY(), SAFEARRAY)),
     ]
 
@@ -973,14 +993,24 @@ register_com_interface(
 
 class CreateObject_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("domainControllerName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("distinguishedName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRFullPointerField(NDRPacketField("attributes", SAFEARRAY(), SAFEARRAY)),
-        NDRPacketField(
-            "verifyNameDomainControllerName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField(
+                "domainControllerName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         ),
-        NDRPacketField(
-            "networkNameResourceName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField("distinguishedName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(NDRPacketField("attributes", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRPacketField(
+                "verifyNameDomainControllerName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
+        NDRFullPointerField(
+            NDRPacketField(
+                "networkNameResourceName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         ),
     ]
 
@@ -991,10 +1021,18 @@ class CreateObject_Response(NDRPacket):
 
 class DeleteObject_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("domainControllerName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("distinguishedName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField(
-            "networkNameResourceName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField(
+                "domainControllerName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
+        NDRFullPointerField(
+            NDRPacketField("distinguishedName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField(
+                "networkNameResourceName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         ),
     ]
 
@@ -1005,11 +1043,19 @@ class DeleteObject_Response(NDRPacket):
 
 class ModifyObject_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("domainControllerName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("distinguishedName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField(
+                "domainControllerName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
+        NDRFullPointerField(
+            NDRPacketField("distinguishedName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRFullPointerField(NDRPacketField("attributes", SAFEARRAY(), SAFEARRAY)),
-        NDRPacketField(
-            "networkNameResourceName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField(
+                "networkNameResourceName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         ),
     ]
 
@@ -1038,7 +1084,9 @@ register_com_interface(
 class GetReport_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("replicationGroupGuid", GUID(), GUID),
-        NDRPacketField("referenceMember", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("referenceMember", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRFullPointerField(
             NDRPacketField("referenceVersionVectors", SAFEARRAY(), SAFEARRAY)
         ),
@@ -1052,7 +1100,9 @@ class GetReport_Response(NDRPacket):
             NDRPacketField("memberVersionVectors", SAFEARRAY(), SAFEARRAY)
         ),
         NDRFullPointerField(
-            NDRPacketField("reportXML", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("reportXML", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1061,7 +1111,9 @@ class GetReport_Response(NDRPacket):
 class GetCompressedReport_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("replicationGroupGuid", GUID(), GUID),
-        NDRPacketField("referenceMember", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("referenceMember", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRFullPointerField(
             NDRPacketField("referenceVersionVectors", SAFEARRAY(), SAFEARRAY)
         ),
@@ -1075,7 +1127,11 @@ class GetCompressedReport_Response(NDRPacket):
             NDRPacketField("memberVersionVectors", SAFEARRAY(), SAFEARRAY)
         ),
         NDRFullPointerField(
-            NDRPacketField("reportCompressed", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "reportCompressed", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRSignedIntField("uncompressedReportSize", 0),
         NDRIntField("status", 0),
@@ -1146,8 +1202,12 @@ register_com_interface(
 class GetReport_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("replicationGroupGuid", GUID(), GUID),
-        NDRPacketField("referenceMember", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("serverName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("referenceMember", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("serverName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRFullPointerField(
             NDRPacketField("referenceVersionVectors", SAFEARRAY(), SAFEARRAY)
         ),
@@ -1161,7 +1221,9 @@ class GetReport_Response(NDRPacket):
             NDRPacketField("memberVersionVectors", SAFEARRAY(), SAFEARRAY)
         ),
         NDRFullPointerField(
-            NDRPacketField("reportXML", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("reportXML", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1170,8 +1232,12 @@ class GetReport_Response(NDRPacket):
 class GetCompressedReport_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("replicationGroupGuid", GUID(), GUID),
-        NDRPacketField("referenceMember", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("serverName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("referenceMember", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("serverName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRFullPointerField(
             NDRPacketField("referenceVersionVectors", SAFEARRAY(), SAFEARRAY)
         ),
@@ -1185,7 +1251,11 @@ class GetCompressedReport_Response(NDRPacket):
             NDRPacketField("memberVersionVectors", SAFEARRAY(), SAFEARRAY)
         ),
         NDRFullPointerField(
-            NDRPacketField("reportCompressed", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "reportCompressed", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRSignedIntField("uncompressedReportSize", 0),
         NDRIntField("status", 0),

--- a/scapy-rpc/msrpcs/ms_dhcpm.py
+++ b/scapy-rpc/msrpcs/ms_dhcpm.py
@@ -32,6 +32,7 @@ from scapy.layers.dcerpc import (
     NDRIntField,
     NDRLongField,
     NDRPacketField,
+    NDRRefEmbPointerField,
     NDRShortField,
     NDRSignedIntField,
     NDRSignedLongField,
@@ -291,7 +292,7 @@ class LPDHCP_SUBNET_ELEMENT_INFO_ARRAY(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
         NDRIntField("NumElements", None, size_of="Elements"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "Elements",
                 [],
@@ -751,7 +752,7 @@ class LPDHCP_OPTION_VALUE_ARRAY(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
         NDRIntField("NumElements", None, size_of="Values"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "Values", [], LPDHCP_OPTION_VALUE, size_is=lambda pkt: pkt.NumElements
             )
@@ -928,13 +929,9 @@ class LPDHCP_CLIENT_INFO_ARRAY(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
         NDRIntField("NumElements", None, size_of="Clients"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
-                "Clients",
-                [],
-                LPDHCP_CLIENT_INFO,
-                size_is=lambda pkt: pkt.NumElements,
-                ptr_pack=True,
+                "Clients", [], LPDHCP_CLIENT_INFO, size_is=lambda pkt: pkt.NumElements
             )
         ),
     ]
@@ -1049,7 +1046,7 @@ class LPDHCP_OPTION_ARRAY(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
         NDRIntField("NumElements", None, size_of="Options"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "Options", [], LPDHCP_OPTION, size_is=lambda pkt: pkt.NumElements
             )
@@ -1317,7 +1314,7 @@ class LPDHCP_SUBNET_ELEMENT_INFO_ARRAY_V4(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
         NDRIntField("NumElements", None, size_of="Elements"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "Elements",
                 [],
@@ -1427,13 +1424,12 @@ class LPDHCP_CLIENT_INFO_ARRAY_V4(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
         NDRIntField("NumElements", None, size_of="Clients"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "Clients",
                 [],
                 LPDHCP_CLIENT_INFO_V4,
                 size_is=lambda pkt: pkt.NumElements,
-                ptr_pack=True,
             )
         ),
     ]
@@ -1771,13 +1767,12 @@ class LPDHCP_CLIENT_INFO_ARRAY_VQ(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
         NDRIntField("NumElements", None, size_of="Clients"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "Clients",
                 [],
                 LPDHCP_CLIENT_INFO_VQ,
                 size_is=lambda pkt: pkt.NumElements,
-                ptr_pack=True,
             )
         ),
     ]
@@ -2222,13 +2217,9 @@ class LPDHCP_MCLIENT_INFO_ARRAY(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
         NDRIntField("NumElements", None, size_of="Clients"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
-                "Clients",
-                [],
-                LPDHCP_MCLIENT_INFO,
-                size_is=lambda pkt: pkt.NumElements,
-                ptr_pack=True,
+                "Clients", [], LPDHCP_MCLIENT_INFO, size_is=lambda pkt: pkt.NumElements
             )
         ),
     ]
@@ -2518,7 +2509,7 @@ class LPDHCP_CLASS_INFO_ARRAY(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
         NDRIntField("NumElements", None, size_of="Classes"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "Classes", [], LPDHCP_CLASS_INFO, size_is=lambda pkt: pkt.NumElements
             )
@@ -2573,7 +2564,7 @@ class LPDHCP_ALL_OPTIONS(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
         NDRIntField("Flags", 0),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRPacketField(
                 "NonVendorOptions", LPDHCP_OPTION_ARRAY(), LPDHCP_OPTION_ARRAY
             )
@@ -2612,7 +2603,7 @@ class Options_DHCP_ALL_OPTION_VALUES(NDRPacket):
         NDRFullEmbPointerField(NDRShortField("ClassName", 0)),
         NDRFullEmbPointerField(NDRShortField("VendorName", 0)),
         NDRSignedIntField("IsVendor", 0),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRPacketField(
                 "OptionsArray", LPDHCP_OPTION_VALUE_ARRAY(), LPDHCP_OPTION_VALUE_ARRAY
             )
@@ -2792,7 +2783,7 @@ class LPDHCP_ATTRIB_ARRAY(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
         NDRIntField("NumElements", None, size_of="DhcpAttribs"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "DhcpAttribs", [], LPDHCP_ATTRIB, size_is=lambda pkt: pkt.NumElements
             )
@@ -2957,7 +2948,7 @@ class LPDHCP_SUBNET_ELEMENT_INFO_ARRAY_V5(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
         NDRIntField("NumElements", None, size_of="Elements"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "Elements",
                 [],
@@ -3598,7 +3589,7 @@ class LPDHCP_SUBNET_ELEMENT_INFO_ARRAY_V6(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
         NDRIntField("NumElements", None, size_of="Elements"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "Elements",
                 [],
@@ -4006,7 +3997,11 @@ class R_DhcpGetClientInfoV6_Request(NDRPacket):
 class R_DhcpGetClientInfoV6_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("ClientInfo", LPDHCP_CLIENT_INFO_V6(), LPDHCP_CLIENT_INFO_V6)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "ClientInfo", LPDHCP_CLIENT_INFO_V6(), LPDHCP_CLIENT_INFO_V6
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -4078,7 +4073,7 @@ class LPDHCP_CLASS_INFO_ARRAY_V6(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
         NDRIntField("NumElements", None, size_of="Classes"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "Classes", [], LPDHCP_CLASS_INFO_V6, size_is=lambda pkt: pkt.NumElements
             )
@@ -4464,7 +4459,7 @@ class LPDHCP_FAILOVER_RELATIONSHIP(NDRPacket):
         NDRFullEmbPointerField(NDRShortField("relationshipName", 0)),
         NDRFullEmbPointerField(NDRShortField("primaryServerName", 0)),
         NDRFullEmbPointerField(NDRShortField("secondaryServerName", 0)),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRPacketField("pScopes", LPDHCP_IP_ARRAY(), LPDHCP_IP_ARRAY)
         ),
         NDRByteField("percentage", 0),
@@ -4538,7 +4533,7 @@ class LPDHCP_FAILOVER_RELATIONSHIP_ARRAY(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
         NDRIntField("numElements", None, size_of="pRelationships"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "pRelationships",
                 [],
@@ -4804,7 +4799,7 @@ class Options_DHCP_ALL_OPTION_VALUES_PB(NDRPacket):
         NDRFullEmbPointerField(NDRShortField("PolicyName", 0)),
         NDRFullEmbPointerField(NDRShortField("VendorName", 0)),
         NDRSignedIntField("IsVendor", 0),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRPacketField(
                 "OptionsArray", LPDHCP_OPTION_VALUE_ARRAY(), LPDHCP_OPTION_VALUE_ARRAY
             )
@@ -5043,7 +5038,7 @@ class LPDHCP_POLICY_ARRAY(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
         NDRIntField("NumElements", None, size_of="Elements"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "Elements", [], LPDHCP_POLICY, size_is=lambda pkt: pkt.NumElements
             )
@@ -5076,7 +5071,9 @@ class R_DhcpV4AddPolicyRange_Request(NDRPacket):
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("ServerIpAddress", "")),
         NDRIntField("SubnetAddress", 0),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("PolicyName", "")),
-        NDRPacketField("Range", LPDHCP_IP_RANGE(), LPDHCP_IP_RANGE),
+        NDRFullPointerField(
+            NDRPacketField("Range", LPDHCP_IP_RANGE(), LPDHCP_IP_RANGE)
+        ),
     ]
 
 
@@ -5089,7 +5086,9 @@ class R_DhcpV4RemovePolicyRange_Request(NDRPacket):
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("ServerIpAddress", "")),
         NDRIntField("SubnetAddress", 0),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("PolicyName", "")),
-        NDRPacketField("Range", LPDHCP_IP_RANGE(), LPDHCP_IP_RANGE),
+        NDRFullPointerField(
+            NDRPacketField("Range", LPDHCP_IP_RANGE(), LPDHCP_IP_RANGE)
+        ),
     ]
 
 
@@ -5345,7 +5344,11 @@ class R_DhcpV4GetClientInfo_Request(NDRPacket):
 class R_DhcpV4GetClientInfo_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("ClientInfo", LPDHCP_CLIENT_INFO_PB(), LPDHCP_CLIENT_INFO_PB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "ClientInfo", LPDHCP_CLIENT_INFO_PB(), LPDHCP_CLIENT_INFO_PB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -5546,7 +5549,7 @@ class LPDHCP_POLICY_EX_ARRAY(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
         NDRIntField("NumElements", None, size_of="Elements"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "Elements", [], LPDHCP_POLICY_EX, size_is=lambda pkt: pkt.NumElements
             )
@@ -5657,7 +5660,11 @@ class R_DhcpV4GetClientInfoEx_Request(NDRPacket):
 class R_DhcpV4GetClientInfoEx_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("ClientInfo", LPDHCP_CLIENT_INFO_EX(), LPDHCP_CLIENT_INFO_EX)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "ClientInfo", LPDHCP_CLIENT_INFO_EX(), LPDHCP_CLIENT_INFO_EX
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]

--- a/scapy-rpc/msrpcs/ms_dnsp.py
+++ b/scapy-rpc/msrpcs/ms_dnsp.py
@@ -5289,12 +5289,8 @@ class R_DnssrvUpdateRecord_Request(NDRPacket):
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("pwszServerName", "")),
         NDRFullPointerField(NDRConfVarStrNullField("pszZone", "")),
         NDRConfVarStrNullField("pszNodeName", ""),
-        NDRFullPointerField(
-            NDRPacketField("pAddRecord", PDNS_RPC_RECORD(), PDNS_RPC_RECORD)
-        ),
-        NDRFullPointerField(
-            NDRPacketField("pDeleteRecord", PDNS_RPC_RECORD(), PDNS_RPC_RECORD)
-        ),
+        NDRPacketField("pAddRecord", PDNS_RPC_RECORD(), PDNS_RPC_RECORD),
+        NDRPacketField("pDeleteRecord", PDNS_RPC_RECORD(), PDNS_RPC_RECORD),
     ]
 
 
@@ -9061,12 +9057,8 @@ class R_DnssrvUpdateRecord2_Request(NDRPacket):
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("pwszServerName", "")),
         NDRFullPointerField(NDRConfVarStrNullField("pszZone", "")),
         NDRConfVarStrNullField("pszNodeName", ""),
-        NDRFullPointerField(
-            NDRPacketField("pAddRecord", PDNS_RPC_RECORD(), PDNS_RPC_RECORD)
-        ),
-        NDRFullPointerField(
-            NDRPacketField("pDeleteRecord", PDNS_RPC_RECORD(), PDNS_RPC_RECORD)
-        ),
+        NDRPacketField("pAddRecord", PDNS_RPC_RECORD(), PDNS_RPC_RECORD),
+        NDRPacketField("pDeleteRecord", PDNS_RPC_RECORD(), PDNS_RPC_RECORD),
     ]
 
 
@@ -9082,12 +9074,8 @@ class R_DnssrvUpdateRecord3_Request(NDRPacket):
         NDRFullPointerField(NDRConfVarStrNullField("pszZone", "")),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("pwszZoneScope", "")),
         NDRConfVarStrNullField("pszNodeName", ""),
-        NDRFullPointerField(
-            NDRPacketField("pAddRecord", PDNS_RPC_RECORD(), PDNS_RPC_RECORD)
-        ),
-        NDRFullPointerField(
-            NDRPacketField("pDeleteRecord", PDNS_RPC_RECORD(), PDNS_RPC_RECORD)
-        ),
+        NDRPacketField("pAddRecord", PDNS_RPC_RECORD(), PDNS_RPC_RECORD),
+        NDRPacketField("pDeleteRecord", PDNS_RPC_RECORD(), PDNS_RPC_RECORD),
     ]
 
 
@@ -14741,12 +14729,8 @@ class R_DnssrvUpdateRecord4_Request(NDRPacket):
         NDRFullPointerField(NDRConfVarStrNullField("pszZone", "")),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("pwszZoneScope", "")),
         NDRConfVarStrNullField("pszNodeName", ""),
-        NDRFullPointerField(
-            NDRPacketField("pAddRecord", PDNS_RPC_RECORD(), PDNS_RPC_RECORD)
-        ),
-        NDRFullPointerField(
-            NDRPacketField("pDeleteRecord", PDNS_RPC_RECORD(), PDNS_RPC_RECORD)
-        ),
+        NDRPacketField("pAddRecord", PDNS_RPC_RECORD(), PDNS_RPC_RECORD),
+        NDRPacketField("pDeleteRecord", PDNS_RPC_RECORD(), PDNS_RPC_RECORD),
     ]
 
 

--- a/scapy-rpc/msrpcs/ms_even.py
+++ b/scapy-rpc/msrpcs/ms_even.py
@@ -55,9 +55,7 @@ class PRPC_UNICODE_STRING(NDRPacket):
 class ElfrClearELFW_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("LogHandle", NDRContextHandle(), NDRContextHandle),
-        NDRFullPointerField(
-            NDRPacketField("BackupFileName", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING)
-        ),
+        NDRPacketField("BackupFileName", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING),
     ]
 
 
@@ -133,7 +131,7 @@ class ElfrChangeNotify_Response(NDRPacket):
 
 class ElfrOpenELW_Request(NDRPacket):
     fields_desc = [
-        NDRShortField("UNCServerName", 0),
+        NDRFullPointerField(NDRShortField("UNCServerName", 0)),
         NDRPacketField("ModuleName", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING),
         NDRPacketField("RegModuleName", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING),
         NDRIntField("MajorVersion", 0),
@@ -150,7 +148,7 @@ class ElfrOpenELW_Response(NDRPacket):
 
 class ElfrRegisterEventSourceW_Request(NDRPacket):
     fields_desc = [
-        NDRShortField("UNCServerName", 0),
+        NDRFullPointerField(NDRShortField("UNCServerName", 0)),
         NDRPacketField("ModuleName", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING),
         NDRPacketField("RegModuleName", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING),
         NDRIntField("MajorVersion", 0),
@@ -167,7 +165,7 @@ class ElfrRegisterEventSourceW_Response(NDRPacket):
 
 class ElfrOpenBELW_Request(NDRPacket):
     fields_desc = [
-        NDRShortField("UNCServerName", 0),
+        NDRFullPointerField(NDRShortField("UNCServerName", 0)),
         NDRPacketField("BackupFileName", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING),
         NDRIntField("MajorVersion", 0),
         NDRIntField("MinorVersion", 0),
@@ -234,13 +232,9 @@ class ElfrReportEventW_Request(NDRPacket):
         NDRShortField("NumStrings", None, size_of="Strings"),
         NDRIntField("DataSize", None, size_of="Data"),
         NDRPacketField("ComputerName", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING),
-        NDRFullPointerField(NDRPacketField("UserSID", PRPC_SID(), PRPC_SID)),
+        NDRPacketField("UserSID", PRPC_SID(), PRPC_SID),
         NDRConfPacketListField(
-            "Strings",
-            [],
-            PRPC_UNICODE_STRING,
-            size_is=lambda pkt: pkt.NumStrings,
-            ptr_pack=True,
+            "Strings", [], PRPC_UNICODE_STRING, size_is=lambda pkt: pkt.NumStrings
         ),
         NDRFullPointerField(
             NDRConfStrLenField("Data", "", size_is=lambda pkt: pkt.DataSize)
@@ -273,9 +267,7 @@ class PRPC_STRING(NDRPacket):
 class ElfrClearELFA_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("LogHandle", NDRContextHandle(), NDRContextHandle),
-        NDRFullPointerField(
-            NDRPacketField("BackupFileName", PRPC_STRING(), PRPC_STRING)
-        ),
+        NDRPacketField("BackupFileName", PRPC_STRING(), PRPC_STRING),
     ]
 
 
@@ -296,7 +288,7 @@ class ElfrBackupELFA_Response(NDRPacket):
 
 class ElfrOpenELA_Request(NDRPacket):
     fields_desc = [
-        NDRSignedByteField("UNCServerName", 0),
+        NDRFullPointerField(NDRSignedByteField("UNCServerName", 0)),
         NDRPacketField("ModuleName", PRPC_STRING(), PRPC_STRING),
         NDRPacketField("RegModuleName", PRPC_STRING(), PRPC_STRING),
         NDRIntField("MajorVersion", 0),
@@ -313,7 +305,7 @@ class ElfrOpenELA_Response(NDRPacket):
 
 class ElfrRegisterEventSourceA_Request(NDRPacket):
     fields_desc = [
-        NDRSignedByteField("UNCServerName", 0),
+        NDRFullPointerField(NDRSignedByteField("UNCServerName", 0)),
         NDRPacketField("ModuleName", PRPC_STRING(), PRPC_STRING),
         NDRPacketField("RegModuleName", PRPC_STRING(), PRPC_STRING),
         NDRIntField("MajorVersion", 0),
@@ -330,7 +322,7 @@ class ElfrRegisterEventSourceA_Response(NDRPacket):
 
 class ElfrOpenBELA_Request(NDRPacket):
     fields_desc = [
-        NDRSignedByteField("UNCServerName", 0),
+        NDRFullPointerField(NDRSignedByteField("UNCServerName", 0)),
         NDRPacketField("BackupFileName", PRPC_STRING(), PRPC_STRING),
         NDRIntField("MajorVersion", 0),
         NDRIntField("MinorVersion", 0),
@@ -372,13 +364,9 @@ class ElfrReportEventA_Request(NDRPacket):
         NDRShortField("NumStrings", None, size_of="Strings"),
         NDRIntField("DataSize", None, size_of="Data"),
         NDRPacketField("ComputerName", PRPC_STRING(), PRPC_STRING),
-        NDRFullPointerField(NDRPacketField("UserSID", PRPC_SID(), PRPC_SID)),
+        NDRPacketField("UserSID", PRPC_SID(), PRPC_SID),
         NDRConfPacketListField(
-            "Strings",
-            [],
-            PRPC_STRING,
-            size_is=lambda pkt: pkt.NumStrings,
-            ptr_pack=True,
+            "Strings", [], PRPC_STRING, size_is=lambda pkt: pkt.NumStrings
         ),
         NDRFullPointerField(
             NDRConfStrLenField("Data", "", size_is=lambda pkt: pkt.DataSize)
@@ -424,13 +412,9 @@ class ElfrReportEventAndSourceW_Request(NDRPacket):
         NDRShortField("NumStrings", None, size_of="Strings"),
         NDRIntField("DataSize", None, size_of="Data"),
         NDRPacketField("ComputerName", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING),
-        NDRFullPointerField(NDRPacketField("UserSID", PRPC_SID(), PRPC_SID)),
+        NDRPacketField("UserSID", PRPC_SID(), PRPC_SID),
         NDRConfPacketListField(
-            "Strings",
-            [],
-            PRPC_UNICODE_STRING,
-            size_is=lambda pkt: pkt.NumStrings,
-            ptr_pack=True,
+            "Strings", [], PRPC_UNICODE_STRING, size_is=lambda pkt: pkt.NumStrings
         ),
         NDRFullPointerField(
             NDRConfStrLenField("Data", "", size_is=lambda pkt: pkt.DataSize)
@@ -464,13 +448,9 @@ class ElfrReportEventExW_Request(NDRPacket):
         NDRShortField("NumStrings", None, size_of="Strings"),
         NDRIntField("DataSize", None, size_of="Data"),
         NDRPacketField("ComputerName", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING),
-        NDRFullPointerField(NDRPacketField("UserSID", PRPC_SID(), PRPC_SID)),
+        NDRPacketField("UserSID", PRPC_SID(), PRPC_SID),
         NDRConfPacketListField(
-            "Strings",
-            [],
-            PRPC_UNICODE_STRING,
-            size_is=lambda pkt: pkt.NumStrings,
-            ptr_pack=True,
+            "Strings", [], PRPC_UNICODE_STRING, size_is=lambda pkt: pkt.NumStrings
         ),
         NDRFullPointerField(
             NDRConfStrLenField("Data", "", size_is=lambda pkt: pkt.DataSize)
@@ -497,13 +477,9 @@ class ElfrReportEventExA_Request(NDRPacket):
         NDRShortField("NumStrings", None, size_of="Strings"),
         NDRIntField("DataSize", None, size_of="Data"),
         NDRPacketField("ComputerName", PRPC_STRING(), PRPC_STRING),
-        NDRFullPointerField(NDRPacketField("UserSID", PRPC_SID(), PRPC_SID)),
+        NDRPacketField("UserSID", PRPC_SID(), PRPC_SID),
         NDRConfPacketListField(
-            "Strings",
-            [],
-            PRPC_STRING,
-            size_is=lambda pkt: pkt.NumStrings,
-            ptr_pack=True,
+            "Strings", [], PRPC_STRING, size_is=lambda pkt: pkt.NumStrings
         ),
         NDRFullPointerField(
             NDRConfStrLenField("Data", "", size_is=lambda pkt: pkt.DataSize)

--- a/scapy-rpc/msrpcs/ms_fasp.py
+++ b/scapy-rpc/msrpcs/ms_fasp.py
@@ -1704,9 +1704,7 @@ class RRPC_FWEnumPhase1SAs_Request(NDRPacket):
     fields_desc = [
         NDRLongField("rpcConnHandle", 0),
         NDRPacketField("hPolicyStore", NDRContextHandle(), NDRContextHandle),
-        NDRFullPointerField(
-            NDRPacketField("pEndpoints", PFW_ENDPOINTS(), PFW_ENDPOINTS)
-        ),
+        NDRPacketField("pEndpoints", PFW_ENDPOINTS(), PFW_ENDPOINTS),
     ]
 
 
@@ -1714,11 +1712,7 @@ class RRPC_FWEnumPhase1SAs_Response(NDRPacket):
     fields_desc = [
         NDRIntField("pdwNumSAs", None, size_of="ppSAs"),
         NDRConfPacketListField(
-            "ppSAs",
-            [],
-            PFW_PHASE1_SA_DETAILS,
-            size_is=lambda pkt: pkt.pdwNumSAs,
-            ptr_pack=True,
+            "ppSAs", [], PFW_PHASE1_SA_DETAILS, size_is=lambda pkt: pkt.pdwNumSAs
         ),
         NDRIntField("status", 0),
     ]
@@ -1759,9 +1753,7 @@ class RRPC_FWEnumPhase2SAs_Request(NDRPacket):
     fields_desc = [
         NDRLongField("rpcConnHandle", 0),
         NDRPacketField("hPolicyStore", NDRContextHandle(), NDRContextHandle),
-        NDRFullPointerField(
-            NDRPacketField("pEndpoints", PFW_ENDPOINTS(), PFW_ENDPOINTS)
-        ),
+        NDRPacketField("pEndpoints", PFW_ENDPOINTS(), PFW_ENDPOINTS),
     ]
 
 
@@ -1769,11 +1761,7 @@ class RRPC_FWEnumPhase2SAs_Response(NDRPacket):
     fields_desc = [
         NDRIntField("pdwNumSAs", None, size_of="ppSAs"),
         NDRConfPacketListField(
-            "ppSAs",
-            [],
-            PFW_PHASE2_SA_DETAILS,
-            size_is=lambda pkt: pkt.pdwNumSAs,
-            ptr_pack=True,
+            "ppSAs", [], PFW_PHASE2_SA_DETAILS, size_is=lambda pkt: pkt.pdwNumSAs
         ),
         NDRIntField("status", 0),
     ]
@@ -1783,9 +1771,7 @@ class RRPC_FWDeletePhase1SAs_Request(NDRPacket):
     fields_desc = [
         NDRLongField("rpcConnHandle", 0),
         NDRPacketField("hPolicyStore", NDRContextHandle(), NDRContextHandle),
-        NDRFullPointerField(
-            NDRPacketField("pEndpoints", PFW_ENDPOINTS(), PFW_ENDPOINTS)
-        ),
+        NDRPacketField("pEndpoints", PFW_ENDPOINTS(), PFW_ENDPOINTS),
     ]
 
 
@@ -1797,9 +1783,7 @@ class RRPC_FWDeletePhase2SAs_Request(NDRPacket):
     fields_desc = [
         NDRLongField("rpcConnHandle", 0),
         NDRPacketField("hPolicyStore", NDRContextHandle(), NDRContextHandle),
-        NDRFullPointerField(
-            NDRPacketField("pEndpoints", PFW_ENDPOINTS(), PFW_ENDPOINTS)
-        ),
+        NDRPacketField("pEndpoints", PFW_ENDPOINTS(), PFW_ENDPOINTS),
     ]
 
 
@@ -1846,11 +1830,7 @@ class RRPC_FWEnumProducts_Response(NDRPacket):
     fields_desc = [
         NDRIntField("pdwNumProducts", None, size_of="ppProducts"),
         NDRConfPacketListField(
-            "ppProducts",
-            [],
-            PFW_PRODUCT,
-            size_is=lambda pkt: pkt.pdwNumProducts,
-            ptr_pack=True,
+            "ppProducts", [], PFW_PRODUCT, size_is=lambda pkt: pkt.pdwNumProducts
         ),
         NDRIntField("status", 0),
     ]
@@ -2496,11 +2476,7 @@ class RRPC_FWEnumNetworks_Response(NDRPacket):
     fields_desc = [
         NDRIntField("pdwNumNetworks", None, size_of="ppNetworks"),
         NDRConfPacketListField(
-            "ppNetworks",
-            [],
-            PFW_NETWORK,
-            size_is=lambda pkt: pkt.pdwNumNetworks,
-            ptr_pack=True,
+            "ppNetworks", [], PFW_NETWORK, size_is=lambda pkt: pkt.pdwNumNetworks
         ),
         NDRIntField("status", 0),
     ]
@@ -2525,11 +2501,7 @@ class RRPC_FWEnumAdapters_Response(NDRPacket):
     fields_desc = [
         NDRIntField("pdwNumAdapters", None, size_of="ppAdapters"),
         NDRConfPacketListField(
-            "ppAdapters",
-            [],
-            PFW_ADAPTER,
-            size_is=lambda pkt: pkt.pdwNumAdapters,
-            ptr_pack=True,
+            "ppAdapters", [], PFW_ADAPTER, size_is=lambda pkt: pkt.pdwNumAdapters
         ),
         NDRIntField("status", 0),
     ]

--- a/scapy-rpc/msrpcs/ms_fsrm.py
+++ b/scapy-rpc/msrpcs/ms_fsrm.py
@@ -1062,12 +1062,14 @@ class Invoke_Request(NDRPacket):
         NDRConfFieldListField(
             "rgVarRefIdx", [], NDRIntField("", 0), size_is=lambda pkt: pkt.cVarRef
         ),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
     ]
 
@@ -1075,16 +1077,20 @@ class Invoke_Request(NDRPacket):
 class Invoke_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRPacketField("pExcepInfo", EXCEPINFO(), EXCEPINFO),
         NDRIntField("pArgErr", 0),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1120,7 +1126,9 @@ class get_IFsrmObject_Description_Request(NDRPacket):
 class get_IFsrmObject_Description_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("description", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("description", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1128,7 +1136,9 @@ class get_IFsrmObject_Description_Response(NDRPacket):
 
 class put_IFsrmObject_Description_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("description", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("description", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1195,7 +1205,11 @@ class get_IFsrmCollection_Item_Request(NDRPacket):
 
 class get_IFsrmCollection_Item_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("item", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("item", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
@@ -1248,7 +1262,11 @@ class GetById_Request(NDRPacket):
 
 class GetById_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("entry", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("entry", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
@@ -1278,7 +1296,9 @@ register_com_interface(
 
 
 class Add_Request(NDRPacket):
-    fields_desc = [NDRPacketField("item", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("item", wireVARIANTStr(), wireVARIANTStr))
+    ]
 
 
 class Add_Response(NDRPacket):
@@ -1475,14 +1495,20 @@ class get_IFsrmActionEmail_MailFrom_Request(NDRPacket):
 class get_IFsrmActionEmail_MailFrom_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("mailFrom", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("mailFrom", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmActionEmail_MailFrom_Request(NDRPacket):
-    fields_desc = [NDRPacketField("mailFrom", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("mailFrom", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmActionEmail_MailFrom_Response(NDRPacket):
@@ -1496,7 +1522,9 @@ class get_IFsrmActionEmail_MailReplyTo_Request(NDRPacket):
 class get_IFsrmActionEmail_MailReplyTo_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("mailReplyTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("mailReplyTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1504,7 +1532,9 @@ class get_IFsrmActionEmail_MailReplyTo_Response(NDRPacket):
 
 class put_IFsrmActionEmail_MailReplyTo_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("mailReplyTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("mailReplyTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1519,14 +1549,20 @@ class get_IFsrmActionEmail_MailTo_Request(NDRPacket):
 class get_IFsrmActionEmail_MailTo_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("mailTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("mailTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmActionEmail_MailTo_Request(NDRPacket):
-    fields_desc = [NDRPacketField("mailTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("mailTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmActionEmail_MailTo_Response(NDRPacket):
@@ -1540,14 +1576,20 @@ class get_IFsrmActionEmail_MailCc_Request(NDRPacket):
 class get_IFsrmActionEmail_MailCc_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("mailCc", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("mailCc", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmActionEmail_MailCc_Request(NDRPacket):
-    fields_desc = [NDRPacketField("mailCc", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("mailCc", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmActionEmail_MailCc_Response(NDRPacket):
@@ -1561,14 +1603,20 @@ class get_IFsrmActionEmail_MailBcc_Request(NDRPacket):
 class get_IFsrmActionEmail_MailBcc_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("mailBcc", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("mailBcc", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmActionEmail_MailBcc_Request(NDRPacket):
-    fields_desc = [NDRPacketField("mailBcc", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("mailBcc", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmActionEmail_MailBcc_Response(NDRPacket):
@@ -1582,7 +1630,9 @@ class get_IFsrmActionEmail_MailSubject_Request(NDRPacket):
 class get_IFsrmActionEmail_MailSubject_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("mailSubject", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("mailSubject", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1590,7 +1640,9 @@ class get_IFsrmActionEmail_MailSubject_Response(NDRPacket):
 
 class put_IFsrmActionEmail_MailSubject_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("mailSubject", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("mailSubject", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1605,7 +1657,9 @@ class get_IFsrmActionEmail_MessageText_Request(NDRPacket):
 class get_IFsrmActionEmail_MessageText_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("messageText", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("messageText", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1613,7 +1667,9 @@ class get_IFsrmActionEmail_MessageText_Response(NDRPacket):
 
 class put_IFsrmActionEmail_MessageText_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("messageText", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("messageText", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1703,13 +1759,17 @@ class get_IFsrmActionReport_ReportTypes_Request(NDRPacket):
 
 class get_IFsrmActionReport_ReportTypes_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("reportTypes", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("reportTypes", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmActionReport_ReportTypes_Request(NDRPacket):
-    fields_desc = [NDRPacketField("reportTypes", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("reportTypes", SAFEARRAY(), SAFEARRAY))
+    ]
 
 
 class put_IFsrmActionReport_ReportTypes_Response(NDRPacket):
@@ -1723,14 +1783,20 @@ class get_IFsrmActionReport_MailTo_Request(NDRPacket):
 class get_IFsrmActionReport_MailTo_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("mailTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("mailTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmActionReport_MailTo_Request(NDRPacket):
-    fields_desc = [NDRPacketField("mailTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("mailTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmActionReport_MailTo_Response(NDRPacket):
@@ -1812,7 +1878,9 @@ class get_IFsrmActionEventLog_MessageText_Request(NDRPacket):
 class get_IFsrmActionEventLog_MessageText_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("messageText", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("messageText", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1820,7 +1888,9 @@ class get_IFsrmActionEventLog_MessageText_Response(NDRPacket):
 
 class put_IFsrmActionEventLog_MessageText_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("messageText", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("messageText", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1879,7 +1949,9 @@ class get_IFsrmActionCommand_ExecutablePath_Request(NDRPacket):
 class get_IFsrmActionCommand_ExecutablePath_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("executablePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("executablePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1887,7 +1959,9 @@ class get_IFsrmActionCommand_ExecutablePath_Response(NDRPacket):
 
 class put_IFsrmActionCommand_ExecutablePath_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("executablePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("executablePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1902,14 +1976,20 @@ class get_IFsrmActionCommand_Arguments_Request(NDRPacket):
 class get_IFsrmActionCommand_Arguments_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("arguments", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("arguments", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmActionCommand_Arguments_Request(NDRPacket):
-    fields_desc = [NDRPacketField("arguments", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("arguments", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmActionCommand_Arguments_Response(NDRPacket):
@@ -1952,7 +2032,11 @@ class get_IFsrmActionCommand_WorkingDirectory_Request(NDRPacket):
 class get_IFsrmActionCommand_WorkingDirectory_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("workingDirectory", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "workingDirectory", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1960,7 +2044,9 @@ class get_IFsrmActionCommand_WorkingDirectory_Response(NDRPacket):
 
 class put_IFsrmActionCommand_WorkingDirectory_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("workingDirectory", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("workingDirectory", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -2105,14 +2191,20 @@ class get_IFsrmSetting_SmtpServer_Request(NDRPacket):
 class get_IFsrmSetting_SmtpServer_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("smtpServer", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("smtpServer", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmSetting_SmtpServer_Request(NDRPacket):
-    fields_desc = [NDRPacketField("smtpServer", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("smtpServer", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmSetting_SmtpServer_Response(NDRPacket):
@@ -2126,14 +2218,20 @@ class get_IFsrmSetting_MailFrom_Request(NDRPacket):
 class get_IFsrmSetting_MailFrom_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("mailFrom", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("mailFrom", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmSetting_MailFrom_Request(NDRPacket):
-    fields_desc = [NDRPacketField("mailFrom", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("mailFrom", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmSetting_MailFrom_Response(NDRPacket):
@@ -2147,14 +2245,20 @@ class get_IFsrmSetting_AdminEmail_Request(NDRPacket):
 class get_IFsrmSetting_AdminEmail_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("adminEmail", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("adminEmail", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmSetting_AdminEmail_Request(NDRPacket):
-    fields_desc = [NDRPacketField("adminEmail", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("adminEmail", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmSetting_AdminEmail_Response(NDRPacket):
@@ -2200,7 +2304,11 @@ class put_IFsrmSetting_EnableScreeningAudit_Response(NDRPacket):
 
 
 class EmailTest_Request(NDRPacket):
-    fields_desc = [NDRPacketField("mailTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("mailTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class EmailTest_Response(NDRPacket):
@@ -2275,12 +2383,18 @@ register_com_interface(
 
 
 class GetSharePathsForLocalPath_Request(NDRPacket):
-    fields_desc = [NDRPacketField("localPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("localPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class GetSharePathsForLocalPath_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("sharePaths", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("sharePaths", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
@@ -2460,14 +2574,20 @@ class get_IFsrmPropertyDefinition_Name_Request(NDRPacket):
 class get_IFsrmPropertyDefinition_Name_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmPropertyDefinition_Name_Request(NDRPacket):
-    fields_desc = [NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmPropertyDefinition_Name_Response(NDRPacket):
@@ -2511,13 +2631,19 @@ class get_IFsrmPropertyDefinition_PossibleValues_Request(NDRPacket):
 
 class get_IFsrmPropertyDefinition_PossibleValues_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("possibleValues", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("possibleValues", SAFEARRAY(), SAFEARRAY)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmPropertyDefinition_PossibleValues_Request(NDRPacket):
-    fields_desc = [NDRPacketField("possibleValues", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("possibleValues", SAFEARRAY(), SAFEARRAY))
+    ]
 
 
 class put_IFsrmPropertyDefinition_PossibleValues_Response(NDRPacket):
@@ -2531,14 +2657,18 @@ class get_IFsrmPropertyDefinition_ValueDescriptions_Request(NDRPacket):
 class get_IFsrmPropertyDefinition_ValueDescriptions_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("valueDescriptions", SAFEARRAY(), SAFEARRAY)
+            NDRFullPointerField(
+                NDRPacketField("valueDescriptions", SAFEARRAY(), SAFEARRAY)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmPropertyDefinition_ValueDescriptions_Request(NDRPacket):
-    fields_desc = [NDRPacketField("valueDescriptions", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("valueDescriptions", SAFEARRAY(), SAFEARRAY))
+    ]
 
 
 class put_IFsrmPropertyDefinition_ValueDescriptions_Response(NDRPacket):
@@ -2551,13 +2681,17 @@ class get_IFsrmPropertyDefinition_Parameters_Request(NDRPacket):
 
 class get_IFsrmPropertyDefinition_Parameters_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("parameters", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("parameters", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmPropertyDefinition_Parameters_Request(NDRPacket):
-    fields_desc = [NDRPacketField("parameters", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("parameters", SAFEARRAY(), SAFEARRAY))
+    ]
 
 
 class put_IFsrmPropertyDefinition_Parameters_Response(NDRPacket):
@@ -2646,14 +2780,20 @@ class get_IFsrmPropertyDefinition2_DisplayName_Request(NDRPacket):
 class get_IFsrmPropertyDefinition2_DisplayName_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmPropertyDefinition2_DisplayName_Request(NDRPacket):
-    fields_desc = [NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmPropertyDefinition2_DisplayName_Response(NDRPacket):
@@ -2772,7 +2912,9 @@ class get_IFsrmPropertyDefinitionValue_Name_Request(NDRPacket):
 class get_IFsrmPropertyDefinitionValue_Name_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2785,7 +2927,9 @@ class get_IFsrmPropertyDefinitionValue_DisplayName_Request(NDRPacket):
 class get_IFsrmPropertyDefinitionValue_DisplayName_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("displayName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("displayName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2798,7 +2942,9 @@ class get_IFsrmPropertyDefinitionValue_Description_Request(NDRPacket):
 class get_IFsrmPropertyDefinitionValue_Description_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("description", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("description", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2811,7 +2957,9 @@ class get_IFsrmPropertyDefinitionValue_UniqueID_Request(NDRPacket):
 class get_IFsrmPropertyDefinitionValue_UniqueID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("uniqueID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("uniqueID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2855,7 +3003,9 @@ class get_IFsrmProperty_Name_Request(NDRPacket):
 class get_IFsrmProperty_Name_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2868,7 +3018,9 @@ class get_IFsrmProperty_Value_Request(NDRPacket):
 class get_IFsrmProperty_Value_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2880,7 +3032,9 @@ class get_IFsrmProperty_Sources_Request(NDRPacket):
 
 class get_IFsrmProperty_Sources_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("sources", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("sources", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
@@ -2922,14 +3076,20 @@ class get_IFsrmRule_Name_Request(NDRPacket):
 class get_IFsrmRule_Name_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmRule_Name_Request(NDRPacket):
-    fields_desc = [NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmRule_Name_Response(NDRPacket):
@@ -2960,8 +3120,10 @@ class get_IFsrmRule_ModuleDefinitionName_Request(NDRPacket):
 class get_IFsrmRule_ModuleDefinitionName_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "moduleDefinitionName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "moduleDefinitionName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -2970,7 +3132,11 @@ class get_IFsrmRule_ModuleDefinitionName_Response(NDRPacket):
 
 class put_IFsrmRule_ModuleDefinitionName_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("moduleDefinitionName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField(
+                "moduleDefinitionName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        )
     ]
 
 
@@ -2984,13 +3150,19 @@ class get_IFsrmRule_NamespaceRoots_Request(NDRPacket):
 
 class get_IFsrmRule_NamespaceRoots_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("namespaceRoots", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("namespaceRoots", SAFEARRAY(), SAFEARRAY)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmRule_NamespaceRoots_Request(NDRPacket):
-    fields_desc = [NDRPacketField("namespaceRoots", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("namespaceRoots", SAFEARRAY(), SAFEARRAY))
+    ]
 
 
 class put_IFsrmRule_NamespaceRoots_Response(NDRPacket):
@@ -3019,13 +3191,17 @@ class get_IFsrmRule_Parameters_Request(NDRPacket):
 
 class get_IFsrmRule_Parameters_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("parameters", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("parameters", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmRule_Parameters_Request(NDRPacket):
-    fields_desc = [NDRPacketField("parameters", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("parameters", SAFEARRAY(), SAFEARRAY))
+    ]
 
 
 class put_IFsrmRule_Parameters_Response(NDRPacket):
@@ -3121,14 +3297,20 @@ class get_IFsrmClassificationRule_PropertyAffected_Request(NDRPacket):
 class get_IFsrmClassificationRule_PropertyAffected_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("property", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("property", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmClassificationRule_PropertyAffected_Request(NDRPacket):
-    fields_desc = [NDRPacketField("property", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("property", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmClassificationRule_PropertyAffected_Response(NDRPacket):
@@ -3142,14 +3324,20 @@ class get_IFsrmClassificationRule_Value_Request(NDRPacket):
 class get_IFsrmClassificationRule_Value_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmClassificationRule_Value_Request(NDRPacket):
-    fields_desc = [NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmClassificationRule_Value_Response(NDRPacket):
@@ -3235,7 +3423,9 @@ class get_IFsrmPipelineModuleDefinition_ModuleClsid_Request(NDRPacket):
 class get_IFsrmPipelineModuleDefinition_ModuleClsid_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("moduleClsid", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("moduleClsid", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -3243,7 +3433,9 @@ class get_IFsrmPipelineModuleDefinition_ModuleClsid_Response(NDRPacket):
 
 class put_IFsrmPipelineModuleDefinition_ModuleClsid_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("moduleClsid", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("moduleClsid", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -3258,14 +3450,20 @@ class get_IFsrmPipelineModuleDefinition_Name_Request(NDRPacket):
 class get_IFsrmPipelineModuleDefinition_Name_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmPipelineModuleDefinition_Name_Request(NDRPacket):
-    fields_desc = [NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmPipelineModuleDefinition_Name_Response(NDRPacket):
@@ -3279,14 +3477,20 @@ class get_IFsrmPipelineModuleDefinition_Company_Request(NDRPacket):
 class get_IFsrmPipelineModuleDefinition_Company_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("company", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("company", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmPipelineModuleDefinition_Company_Request(NDRPacket):
-    fields_desc = [NDRPacketField("company", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("company", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmPipelineModuleDefinition_Company_Response(NDRPacket):
@@ -3300,14 +3504,20 @@ class get_IFsrmPipelineModuleDefinition_Version_Request(NDRPacket):
 class get_IFsrmPipelineModuleDefinition_Version_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("version", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("version", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmPipelineModuleDefinition_Version_Request(NDRPacket):
-    fields_desc = [NDRPacketField("version", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("version", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmPipelineModuleDefinition_Version_Response(NDRPacket):
@@ -3389,14 +3599,20 @@ class get_IFsrmPipelineModuleDefinition_SupportedExtensions_Request(NDRPacket):
 class get_IFsrmPipelineModuleDefinition_SupportedExtensions_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("supportedExtensions", SAFEARRAY(), SAFEARRAY)
+            NDRFullPointerField(
+                NDRPacketField("supportedExtensions", SAFEARRAY(), SAFEARRAY)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmPipelineModuleDefinition_SupportedExtensions_Request(NDRPacket):
-    fields_desc = [NDRPacketField("supportedExtensions", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("supportedExtensions", SAFEARRAY(), SAFEARRAY)
+        )
+    ]
 
 
 class put_IFsrmPipelineModuleDefinition_SupportedExtensions_Response(NDRPacket):
@@ -3409,13 +3625,17 @@ class get_IFsrmPipelineModuleDefinition_Parameters_Request(NDRPacket):
 
 class get_IFsrmPipelineModuleDefinition_Parameters_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("parameters", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("parameters", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmPipelineModuleDefinition_Parameters_Request(NDRPacket):
-    fields_desc = [NDRPacketField("parameters", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("parameters", SAFEARRAY(), SAFEARRAY))
+    ]
 
 
 class put_IFsrmPipelineModuleDefinition_Parameters_Response(NDRPacket):
@@ -3529,14 +3749,20 @@ class get_IFsrmClassifierModuleDefinition_PropertiesAffected_Request(NDRPacket):
 class get_IFsrmClassifierModuleDefinition_PropertiesAffected_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("propertiesAffected", SAFEARRAY(), SAFEARRAY)
+            NDRFullPointerField(
+                NDRPacketField("propertiesAffected", SAFEARRAY(), SAFEARRAY)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmClassifierModuleDefinition_PropertiesAffected_Request(NDRPacket):
-    fields_desc = [NDRPacketField("propertiesAffected", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("propertiesAffected", SAFEARRAY(), SAFEARRAY)
+        )
+    ]
 
 
 class put_IFsrmClassifierModuleDefinition_PropertiesAffected_Response(NDRPacket):
@@ -3549,13 +3775,19 @@ class get_IFsrmClassifierModuleDefinition_PropertiesUsed_Request(NDRPacket):
 
 class get_IFsrmClassifierModuleDefinition_PropertiesUsed_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("propertiesUsed", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("propertiesUsed", SAFEARRAY(), SAFEARRAY)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmClassifierModuleDefinition_PropertiesUsed_Request(NDRPacket):
-    fields_desc = [NDRPacketField("propertiesUsed", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("propertiesUsed", SAFEARRAY(), SAFEARRAY))
+    ]
 
 
 class put_IFsrmClassifierModuleDefinition_PropertiesUsed_Response(NDRPacket):
@@ -3711,13 +3943,17 @@ class get_IFsrmClassificationManager_ClassificationReportFormats_Request(NDRPack
 
 class get_IFsrmClassificationManager_ClassificationReportFormats_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("formats", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("formats", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmClassificationManager_ClassificationReportFormats_Request(NDRPacket):
-    fields_desc = [NDRPacketField("formats", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("formats", SAFEARRAY(), SAFEARRAY))
+    ]
 
 
 class put_IFsrmClassificationManager_ClassificationReportFormats_Response(NDRPacket):
@@ -3747,14 +3983,20 @@ class get_IFsrmClassificationManager_ClassificationReportMailTo_Request(NDRPacke
 class get_IFsrmClassificationManager_ClassificationReportMailTo_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("mailTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("mailTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmClassificationManager_ClassificationReportMailTo_Request(NDRPacket):
-    fields_desc = [NDRPacketField("mailTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("mailTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmClassificationManager_ClassificationReportMailTo_Response(NDRPacket):
@@ -3788,7 +4030,9 @@ class get_IFsrmClassificationManager_ClassificationLastReportPathWithoutExtensio
 ):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("lastReportPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("lastReportPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -3801,7 +4045,9 @@ class get_IFsrmClassificationManager_ClassificationLastError_Request(NDRPacket):
 class get_IFsrmClassificationManager_ClassificationLastError_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("lastError", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("lastError", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -3863,7 +4109,9 @@ class CreatePropertyDefinition_Response(NDRPacket):
 
 class GetPropertyDefinition_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("propertyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("propertyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -3907,7 +4155,9 @@ class CreateRule_Response(NDRPacket):
 
 class GetRule_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("ruleName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("ruleName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRInt3264EnumField("ruleType", 0, FsrmRuleType),
     ]
 
@@ -3952,7 +4202,9 @@ class CreateModuleDefinition_Response(NDRPacket):
 
 class GetModuleDefinition_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("moduleName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("moduleName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRInt3264EnumField("moduleType", 0, FsrmPipelineModuleType),
     ]
 
@@ -3976,7 +4228,9 @@ class FsrmReportGenerationContext(IntEnum):
 class RunClassification_Request(NDRPacket):
     fields_desc = [
         NDRInt3264EnumField("context", 0, FsrmReportGenerationContext),
-        NDRPacketField("reserved", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("reserved", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -4010,7 +4264,9 @@ class FsrmGetFilePropertyOptions(IntEnum):
 
 class EnumFileProperties_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("filePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("filePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRInt3264EnumField("options", 0, FsrmGetFilePropertyOptions),
     ]
 
@@ -4026,8 +4282,12 @@ class EnumFileProperties_Response(NDRPacket):
 
 class GetFileProperty_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("filePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("propertyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("filePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("propertyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRInt3264EnumField("options", 0, FsrmGetFilePropertyOptions),
     ]
 
@@ -4043,9 +4303,15 @@ class GetFileProperty_Response(NDRPacket):
 
 class SetFileProperty_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("filePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("propertyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("propertyValue", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("filePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("propertyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("propertyValue", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -4055,8 +4321,12 @@ class SetFileProperty_Response(NDRPacket):
 
 class ClearFileProperty_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("filePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("property", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("filePath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("property", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -4346,14 +4616,20 @@ class get_IFsrmQuotaBase_QuotaLimit_Request(NDRPacket):
 class get_IFsrmQuotaBase_QuotaLimit_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("quotaLimit", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("quotaLimit", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmQuotaBase_QuotaLimit_Request(NDRPacket):
-    fields_desc = [NDRPacketField("quotaLimit", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("quotaLimit", wireVARIANTStr(), wireVARIANTStr)
+        )
+    ]
 
 
 class put_IFsrmQuotaBase_QuotaLimit_Response(NDRPacket):
@@ -4382,7 +4658,9 @@ class get_IFsrmQuotaBase_Thresholds_Request(NDRPacket):
 
 class get_IFsrmQuotaBase_Thresholds_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("thresholds", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("thresholds", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
@@ -4494,7 +4772,9 @@ class get_IFsrmQuotaObject_Path_Request(NDRPacket):
 class get_IFsrmQuotaObject_Path_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -4507,7 +4787,9 @@ class get_IFsrmQuotaObject_UserSid_Request(NDRPacket):
 class get_IFsrmQuotaObject_UserSid_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("userSid", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("userSid", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -4520,7 +4802,9 @@ class get_IFsrmQuotaObject_UserAccount_Request(NDRPacket):
 class get_IFsrmQuotaObject_UserAccount_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("userAccount", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("userAccount", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -4533,7 +4817,11 @@ class get_IFsrmQuotaObject_SourceTemplateName_Request(NDRPacket):
 class get_IFsrmQuotaObject_SourceTemplateName_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("quotaTemplateName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "quotaTemplateName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -4549,7 +4837,9 @@ class get_IFsrmQuotaObject_MatchesSourceTemplate_Response(NDRPacket):
 
 class ApplyTemplate_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("quotaTemplateName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("quotaTemplateName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -4624,7 +4914,11 @@ class get_IFsrmQuota_QuotaUsed_Request(NDRPacket):
 
 class get_IFsrmQuota_QuotaUsed_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("used", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("used", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
@@ -4636,7 +4930,9 @@ class get_IFsrmQuota_QuotaPeakUsage_Request(NDRPacket):
 class get_IFsrmQuota_QuotaPeakUsage_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("peakUsage", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("peakUsage", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -4743,13 +5039,17 @@ class get_IFsrmAutoApplyQuota_ExcludeFolders_Request(NDRPacket):
 
 class get_IFsrmAutoApplyQuota_ExcludeFolders_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("folders", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("folders", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmAutoApplyQuota_ExcludeFolders_Request(NDRPacket):
-    fields_desc = [NDRPacketField("folders", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("folders", SAFEARRAY(), SAFEARRAY))
+    ]
 
 
 class put_IFsrmAutoApplyQuota_ExcludeFolders_Response(NDRPacket):
@@ -4855,7 +5155,9 @@ class get_IFsrmQuotaManager_ActionVariables_Request(NDRPacket):
 
 class get_IFsrmQuotaManager_ActionVariables_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("variables", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("variables", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
@@ -4866,13 +5168,19 @@ class get_IFsrmQuotaManager_ActionVariableDescriptions_Request(NDRPacket):
 
 class get_IFsrmQuotaManager_ActionVariableDescriptions_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("descriptions", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("descriptions", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class CreateQuota_Request(NDRPacket):
-    fields_desc = [NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class CreateQuota_Response(NDRPacket):
@@ -4886,8 +5194,12 @@ class CreateQuota_Response(NDRPacket):
 
 class CreateAutoApplyQuota_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("quotaTemplateName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("quotaTemplateName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -4901,7 +5213,11 @@ class CreateAutoApplyQuota_Response(NDRPacket):
 
 
 class GetQuota_Request(NDRPacket):
-    fields_desc = [NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class GetQuota_Response(NDRPacket):
@@ -4914,7 +5230,11 @@ class GetQuota_Response(NDRPacket):
 
 
 class GetAutoApplyQuota_Request(NDRPacket):
-    fields_desc = [NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class GetAutoApplyQuota_Response(NDRPacket):
@@ -4927,7 +5247,11 @@ class GetAutoApplyQuota_Response(NDRPacket):
 
 
 class GetRestrictiveQuota_Request(NDRPacket):
-    fields_desc = [NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class GetRestrictiveQuota_Response(NDRPacket):
@@ -4941,7 +5265,9 @@ class GetRestrictiveQuota_Response(NDRPacket):
 
 class EnumQuotas_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRInt3264EnumField("options", 0, FsrmEnumOptions),
     ]
 
@@ -4957,7 +5283,9 @@ class EnumQuotas_Response(NDRPacket):
 
 class EnumAutoApplyQuotas_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRInt3264EnumField("options", 0, FsrmEnumOptions),
     ]
 
@@ -4973,7 +5301,9 @@ class EnumAutoApplyQuotas_Response(NDRPacket):
 
 class EnumEffectiveQuotas_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRInt3264EnumField("options", 0, FsrmEnumOptions),
     ]
 
@@ -4988,7 +5318,11 @@ class EnumEffectiveQuotas_Response(NDRPacket):
 
 
 class Scan_Request(NDRPacket):
-    fields_desc = [NDRPacketField("strPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("strPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class Scan_Response(NDRPacket):
@@ -5048,14 +5382,20 @@ class get_IFsrmQuotaTemplate_Name_Request(NDRPacket):
 class get_IFsrmQuotaTemplate_Name_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmQuotaTemplate_Name_Request(NDRPacket):
-    fields_desc = [NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmQuotaTemplate_Name_Response(NDRPacket):
@@ -5064,7 +5404,9 @@ class put_IFsrmQuotaTemplate_Name_Response(NDRPacket):
 
 class CopyTemplate_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("quotaTemplateName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("quotaTemplateName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -5232,7 +5574,11 @@ class CreateTemplate_Response(NDRPacket):
 
 
 class GetTemplate_Request(NDRPacket):
-    fields_desc = [NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class GetTemplate_Response(NDRPacket):
@@ -5260,7 +5606,11 @@ class EnumTemplates_Response(NDRPacket):
 class ExportTemplates_Request(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("quotaTemplateNamesArray", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "quotaTemplateNamesArray", wireVARIANTStr(), wireVARIANTStr
+                )
+            )
         )
     ]
 
@@ -5268,8 +5618,10 @@ class ExportTemplates_Request(NDRPacket):
 class ExportTemplates_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "serializedQuotaTemplates", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "serializedQuotaTemplates", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -5278,11 +5630,17 @@ class ExportTemplates_Response(NDRPacket):
 
 class ImportTemplates_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField(
-            "serializedQuotaTemplates", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField(
+                "serializedQuotaTemplates", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         ),
         NDRFullPointerField(
-            NDRPacketField("quotaTemplateNamesArray", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "quotaTemplateNamesArray", wireVARIANTStr(), wireVARIANTStr
+                )
+            )
         ),
     ]
 
@@ -5318,7 +5676,9 @@ register_com_interface(
 
 class IsAffectedByQuota_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRInt3264EnumField("options", 0, FsrmEnumOptions),
     ]
 
@@ -5388,7 +5748,11 @@ class CreateReportJob_Response(NDRPacket):
 
 
 class GetReportJob_Request(NDRPacket):
-    fields_desc = [NDRPacketField("taskName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("taskName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class GetReportJob_Response(NDRPacket):
@@ -5407,7 +5771,9 @@ class GetOutputDirectory_Request(NDRPacket):
 class GetOutputDirectory_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -5416,7 +5782,9 @@ class GetOutputDirectory_Response(NDRPacket):
 class SetOutputDirectory_Request(NDRPacket):
     fields_desc = [
         NDRInt3264EnumField("context", 0, FsrmReportGenerationContext),
-        NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -5473,7 +5841,9 @@ class GetDefaultFilter_Request(NDRPacket):
 class GetDefaultFilter_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("filterValue", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("filterValue", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -5483,7 +5853,9 @@ class SetDefaultFilter_Request(NDRPacket):
     fields_desc = [
         NDRInt3264EnumField("reportType", 0, FsrmReportType),
         NDRInt3264EnumField("filter", 0, FsrmReportFilter),
-        NDRPacketField("filterValue", wireVARIANTStr(), wireVARIANTStr),
+        NDRFullPointerField(
+            NDRPacketField("filterValue", wireVARIANTStr(), wireVARIANTStr)
+        ),
     ]
 
 
@@ -5513,7 +5885,9 @@ class GetReportSizeLimit_Request(NDRPacket):
 class GetReportSizeLimit_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("limitValue", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("limitValue", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -5522,7 +5896,9 @@ class GetReportSizeLimit_Response(NDRPacket):
 class SetReportSizeLimit_Request(NDRPacket):
     fields_desc = [
         NDRInt3264EnumField("limit", 0, FsrmReportLimit),
-        NDRPacketField("limitValue", wireVARIANTStr(), wireVARIANTStr),
+        NDRFullPointerField(
+            NDRPacketField("limitValue", wireVARIANTStr(), wireVARIANTStr)
+        ),
     ]
 
 
@@ -5565,14 +5941,20 @@ class get_IFsrmReportJob_Task_Request(NDRPacket):
 class get_IFsrmReportJob_Task_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("taskName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("taskName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmReportJob_Task_Request(NDRPacket):
-    fields_desc = [NDRPacketField("taskName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("taskName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmReportJob_Task_Response(NDRPacket):
@@ -5585,13 +5967,19 @@ class get_IFsrmReportJob_NamespaceRoots_Request(NDRPacket):
 
 class get_IFsrmReportJob_NamespaceRoots_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("namespaceRoots", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("namespaceRoots", SAFEARRAY(), SAFEARRAY)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmReportJob_NamespaceRoots_Request(NDRPacket):
-    fields_desc = [NDRPacketField("namespaceRoots", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("namespaceRoots", SAFEARRAY(), SAFEARRAY))
+    ]
 
 
 class put_IFsrmReportJob_NamespaceRoots_Response(NDRPacket):
@@ -5604,13 +5992,17 @@ class get_IFsrmReportJob_Formats_Request(NDRPacket):
 
 class get_IFsrmReportJob_Formats_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("formats", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("formats", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmReportJob_Formats_Request(NDRPacket):
-    fields_desc = [NDRPacketField("formats", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("formats", SAFEARRAY(), SAFEARRAY))
+    ]
 
 
 class put_IFsrmReportJob_Formats_Response(NDRPacket):
@@ -5624,14 +6016,20 @@ class get_IFsrmReportJob_MailTo_Request(NDRPacket):
 class get_IFsrmReportJob_MailTo_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("mailTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("mailTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmReportJob_MailTo_Request(NDRPacket):
-    fields_desc = [NDRPacketField("mailTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("mailTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmReportJob_MailTo_Response(NDRPacket):
@@ -5664,7 +6062,9 @@ class get_IFsrmReportJob_LastError_Request(NDRPacket):
 class get_IFsrmReportJob_LastError_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("lastError", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("lastError", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -5677,7 +6077,9 @@ class get_IFsrmReportJob_LastGeneratedInDirectory_Request(NDRPacket):
 class get_IFsrmReportJob_LastGeneratedInDirectory_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -5813,14 +6215,20 @@ class get_IFsrmReport_Name_Request(NDRPacket):
 class get_IFsrmReport_Name_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmReport_Name_Request(NDRPacket):
-    fields_desc = [NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmReport_Name_Response(NDRPacket):
@@ -5834,7 +6242,9 @@ class get_IFsrmReport_Description_Request(NDRPacket):
 class get_IFsrmReport_Description_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("description", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("description", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -5842,7 +6252,9 @@ class get_IFsrmReport_Description_Response(NDRPacket):
 
 class put_IFsrmReport_Description_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("description", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("description", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -5857,7 +6269,9 @@ class get_IFsrmReport_LastGeneratedFileNamePrefix_Request(NDRPacket):
 class get_IFsrmReport_LastGeneratedFileNamePrefix_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("prefix", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("prefix", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -5870,7 +6284,9 @@ class GetFilter_Request(NDRPacket):
 class GetFilter_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("filterValue", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("filterValue", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -5879,7 +6295,9 @@ class GetFilter_Response(NDRPacket):
 class SetFilter_Request(NDRPacket):
     fields_desc = [
         NDRInt3264EnumField("filter", 0, FsrmReportFilter),
-        NDRPacketField("filterValue", wireVARIANTStr(), wireVARIANTStr),
+        NDRFullPointerField(
+            NDRPacketField("filterValue", wireVARIANTStr(), wireVARIANTStr)
+        ),
     ]
 
 
@@ -5933,7 +6351,9 @@ class get_IFsrmFileManagementJobManager_ActionVariables_Request(NDRPacket):
 
 class get_IFsrmFileManagementJobManager_ActionVariables_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("variables", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("variables", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
@@ -5944,7 +6364,9 @@ class get_IFsrmFileManagementJobManager_ActionVariableDescriptions_Request(NDRPa
 
 class get_IFsrmFileManagementJobManager_ActionVariableDescriptions_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("descriptions", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("descriptions", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
@@ -5976,7 +6398,11 @@ class CreateFileManagementJob_Response(NDRPacket):
 
 
 class GetFileManagementJob_Request(NDRPacket):
-    fields_desc = [NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class GetFileManagementJob_Response(NDRPacket):
@@ -6022,14 +6448,20 @@ class get_IFsrmFileManagementJob_Name_Request(NDRPacket):
 class get_IFsrmFileManagementJob_Name_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmFileManagementJob_Name_Request(NDRPacket):
-    fields_desc = [NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmFileManagementJob_Name_Response(NDRPacket):
@@ -6042,13 +6474,19 @@ class get_IFsrmFileManagementJob_NamespaceRoots_Request(NDRPacket):
 
 class get_IFsrmFileManagementJob_NamespaceRoots_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("namespaceRoots", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("namespaceRoots", SAFEARRAY(), SAFEARRAY)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmFileManagementJob_NamespaceRoots_Request(NDRPacket):
-    fields_desc = [NDRPacketField("namespaceRoots", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("namespaceRoots", SAFEARRAY(), SAFEARRAY))
+    ]
 
 
 class put_IFsrmFileManagementJob_NamespaceRoots_Response(NDRPacket):
@@ -6104,8 +6542,10 @@ class get_IFsrmFileManagementJob_ExpirationDirectory_Request(NDRPacket):
 class get_IFsrmFileManagementJob_ExpirationDirectory_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "expirationDirectory", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "expirationDirectory", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -6114,7 +6554,11 @@ class get_IFsrmFileManagementJob_ExpirationDirectory_Response(NDRPacket):
 
 class put_IFsrmFileManagementJob_ExpirationDirectory_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("expirationDirectory", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField(
+                "expirationDirectory", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        )
     ]
 
 
@@ -6141,7 +6585,9 @@ class get_IFsrmFileManagementJob_Notifications_Request(NDRPacket):
 
 class get_IFsrmFileManagementJob_Notifications_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("notifications", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("notifications", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
@@ -6184,13 +6630,17 @@ class get_IFsrmFileManagementJob_Formats_Request(NDRPacket):
 
 class get_IFsrmFileManagementJob_Formats_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("formats", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("formats", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmFileManagementJob_Formats_Request(NDRPacket):
-    fields_desc = [NDRPacketField("formats", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("formats", SAFEARRAY(), SAFEARRAY))
+    ]
 
 
 class put_IFsrmFileManagementJob_Formats_Response(NDRPacket):
@@ -6204,14 +6654,20 @@ class get_IFsrmFileManagementJob_MailTo_Request(NDRPacket):
 class get_IFsrmFileManagementJob_MailTo_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("mailTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("mailTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmFileManagementJob_MailTo_Request(NDRPacket):
-    fields_desc = [NDRPacketField("mailTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("mailTo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmFileManagementJob_MailTo_Response(NDRPacket):
@@ -6302,14 +6758,20 @@ class get_IFsrmFileManagementJob_Task_Request(NDRPacket):
 class get_IFsrmFileManagementJob_Task_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("taskName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("taskName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmFileManagementJob_Task_Request(NDRPacket):
-    fields_desc = [NDRPacketField("taskName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("taskName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmFileManagementJob_Task_Response(NDRPacket):
@@ -6322,13 +6784,17 @@ class get_IFsrmFileManagementJob_Parameters_Request(NDRPacket):
 
 class get_IFsrmFileManagementJob_Parameters_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("parameters", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("parameters", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmFileManagementJob_Parameters_Request(NDRPacket):
-    fields_desc = [NDRPacketField("parameters", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("parameters", SAFEARRAY(), SAFEARRAY))
+    ]
 
 
 class put_IFsrmFileManagementJob_Parameters_Response(NDRPacket):
@@ -6353,7 +6819,9 @@ class get_IFsrmFileManagementJob_LastError_Request(NDRPacket):
 class get_IFsrmFileManagementJob_LastError_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("lastError", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("lastError", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -6366,7 +6834,9 @@ class get_IFsrmFileManagementJob_LastReportPathWithoutExtension_Request(NDRPacke
 class get_IFsrmFileManagementJob_LastReportPathWithoutExtension_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -6387,7 +6857,11 @@ class get_IFsrmFileManagementJob_FileNamePattern_Request(NDRPacket):
 class get_IFsrmFileManagementJob_FileNamePattern_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("fileNamePattern", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "fileNamePattern", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -6396,7 +6870,11 @@ class get_IFsrmFileManagementJob_FileNamePattern_Response(NDRPacket):
 class put_IFsrmFileManagementJob_FileNamePattern_Request(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("fileNamePattern", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "fileNamePattern", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         )
     ]
 
@@ -6483,7 +6961,11 @@ class EnumNotificationActions_Response(NDRPacket):
 
 
 class CreatePropertyCondition_Request(NDRPacket):
-    fields_desc = [NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class CreatePropertyCondition_Response(NDRPacket):
@@ -6706,14 +7188,20 @@ class get_IFsrmPropertyCondition_Name_Request(NDRPacket):
 class get_IFsrmPropertyCondition_Name_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmPropertyCondition_Name_Request(NDRPacket):
-    fields_desc = [NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmPropertyCondition_Name_Response(NDRPacket):
@@ -6762,14 +7250,20 @@ class get_IFsrmPropertyCondition_Value_Request(NDRPacket):
 class get_IFsrmPropertyCondition_Value_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmPropertyCondition_Value_Request(NDRPacket):
-    fields_desc = [NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmPropertyCondition_Value_Response(NDRPacket):
@@ -6828,7 +7322,9 @@ register_dcerpc_interface(
 class VerifyNamespaces_Request(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("namespacesSafeArray", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("namespacesSafeArray", wireVARIANTStr(), wireVARIANTStr)
+            )
         )
     ]
 
@@ -6839,11 +7335,17 @@ class VerifyNamespaces_Response(NDRPacket):
 
 class CreateScheduleTask_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("taskName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
         NDRFullPointerField(
-            NDRPacketField("namespacesSafeArray", wireVARIANTStr(), wireVARIANTStr)
+            NDRPacketField("taskName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
         ),
-        NDRPacketField("serializedTask", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("namespacesSafeArray", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
+        NDRFullPointerField(
+            NDRPacketField("serializedTask", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -6853,11 +7355,17 @@ class CreateScheduleTask_Response(NDRPacket):
 
 class ModifyScheduleTask_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("taskName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
         NDRFullPointerField(
-            NDRPacketField("namespacesSafeArray", wireVARIANTStr(), wireVARIANTStr)
+            NDRPacketField("taskName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
         ),
-        NDRPacketField("serializedTask", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("namespacesSafeArray", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
+        NDRFullPointerField(
+            NDRPacketField("serializedTask", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -6866,7 +7374,11 @@ class ModifyScheduleTask_Response(NDRPacket):
 
 
 class DeleteScheduleTask_Request(NDRPacket):
-    fields_desc = [NDRPacketField("taskName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("taskName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class DeleteScheduleTask_Response(NDRPacket):
@@ -6900,14 +7412,20 @@ class get_IFsrmFileGroup_Name_Request(NDRPacket):
 class get_IFsrmFileGroup_Name_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmFileGroup_Name_Request(NDRPacket):
-    fields_desc = [NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmFileGroup_Name_Response(NDRPacket):
@@ -7070,7 +7588,11 @@ class CreateFileGroup_Response(NDRPacket):
 
 
 class GetFileGroup_Request(NDRPacket):
-    fields_desc = [NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class GetFileGroup_Response(NDRPacket):
@@ -7098,7 +7620,9 @@ class EnumFileGroups_Response(NDRPacket):
 class ExportFileGroups_Request(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("fileGroupNamesArray", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("fileGroupNamesArray", wireVARIANTStr(), wireVARIANTStr)
+            )
         )
     ]
 
@@ -7106,8 +7630,10 @@ class ExportFileGroups_Request(NDRPacket):
 class ExportFileGroups_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "serializedFileGroups", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "serializedFileGroups", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -7116,9 +7642,15 @@ class ExportFileGroups_Response(NDRPacket):
 
 class ImportFileGroups_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("serializedFileGroups", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
         NDRFullPointerField(
-            NDRPacketField("fileGroupNamesArray", wireVARIANTStr(), wireVARIANTStr)
+            NDRPacketField(
+                "serializedFileGroups", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("fileGroupNamesArray", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
     ]
 
@@ -7264,7 +7796,9 @@ class get_IFsrmFileScreen_Path_Request(NDRPacket):
 class get_IFsrmFileScreen_Path_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -7277,8 +7811,10 @@ class get_IFsrmFileScreen_SourceTemplateName_Request(NDRPacket):
 class get_IFsrmFileScreen_SourceTemplateName_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "fileScreenTemplateName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "fileScreenTemplateName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -7300,7 +7836,9 @@ class get_IFsrmFileScreen_UserSid_Request(NDRPacket):
 class get_IFsrmFileScreen_UserSid_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("userSid", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("userSid", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -7313,7 +7851,9 @@ class get_IFsrmFileScreen_UserAccount_Request(NDRPacket):
 class get_IFsrmFileScreen_UserAccount_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("userAccount", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("userAccount", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -7321,7 +7861,11 @@ class get_IFsrmFileScreen_UserAccount_Response(NDRPacket):
 
 class ApplyTemplate_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("fileScreenTemplateName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField(
+                "fileScreenTemplateName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        )
     ]
 
 
@@ -7395,7 +7939,9 @@ class get_IFsrmFileScreenException_Path_Request(NDRPacket):
 class get_IFsrmFileScreenException_Path_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -7464,7 +8010,9 @@ class get_IFsrmFileScreenManager_ActionVariables_Request(NDRPacket):
 
 class get_IFsrmFileScreenManager_ActionVariables_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("variables", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("variables", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
@@ -7475,13 +8023,19 @@ class get_IFsrmFileScreenManager_ActionVariableDescriptions_Request(NDRPacket):
 
 class get_IFsrmFileScreenManager_ActionVariableDescriptions_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("descriptions", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("descriptions", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class CreateFileScreen_Request(NDRPacket):
-    fields_desc = [NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class CreateFileScreen_Response(NDRPacket):
@@ -7494,7 +8048,11 @@ class CreateFileScreen_Response(NDRPacket):
 
 
 class GetFileScreen_Request(NDRPacket):
-    fields_desc = [NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class GetFileScreen_Response(NDRPacket):
@@ -7508,7 +8066,9 @@ class GetFileScreen_Response(NDRPacket):
 
 class EnumFileScreens_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRInt3264EnumField("options", 0, FsrmEnumOptions),
     ]
 
@@ -7523,7 +8083,11 @@ class EnumFileScreens_Response(NDRPacket):
 
 
 class CreateFileScreenException_Request(NDRPacket):
-    fields_desc = [NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class CreateFileScreenException_Response(NDRPacket):
@@ -7538,7 +8102,11 @@ class CreateFileScreenException_Response(NDRPacket):
 
 
 class GetFileScreenException_Request(NDRPacket):
-    fields_desc = [NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class GetFileScreenException_Response(NDRPacket):
@@ -7554,7 +8122,9 @@ class GetFileScreenException_Response(NDRPacket):
 
 class EnumFileScreenExceptions_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRInt3264EnumField("options", 0, FsrmEnumOptions),
     ]
 
@@ -7622,14 +8192,20 @@ class get_IFsrmFileScreenTemplate_Name_Request(NDRPacket):
 class get_IFsrmFileScreenTemplate_Name_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IFsrmFileScreenTemplate_Name_Request(NDRPacket):
-    fields_desc = [NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IFsrmFileScreenTemplate_Name_Response(NDRPacket):
@@ -7638,7 +8214,11 @@ class put_IFsrmFileScreenTemplate_Name_Response(NDRPacket):
 
 class CopyTemplate_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("fileScreenTemplateName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField(
+                "fileScreenTemplateName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        )
     ]
 
 
@@ -7806,7 +8386,11 @@ class CreateTemplate_Response(NDRPacket):
 
 
 class GetTemplate_Request(NDRPacket):
-    fields_desc = [NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class GetTemplate_Response(NDRPacket):
@@ -7836,8 +8420,10 @@ class EnumTemplates_Response(NDRPacket):
 class ExportTemplates_Request(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "fileScreenTemplateNamesArray", wireVARIANTStr(), wireVARIANTStr
+            NDRFullPointerField(
+                NDRPacketField(
+                    "fileScreenTemplateNamesArray", wireVARIANTStr(), wireVARIANTStr
+                )
             )
         )
     ]
@@ -7846,8 +8432,12 @@ class ExportTemplates_Request(NDRPacket):
 class ExportTemplates_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "serializedFileScreenTemplates", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "serializedFileScreenTemplates",
+                    FLAGGED_WORD_BLOB(),
+                    FLAGGED_WORD_BLOB,
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -7856,12 +8446,16 @@ class ExportTemplates_Response(NDRPacket):
 
 class ImportTemplates_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField(
-            "serializedFileScreenTemplates", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
-        ),
         NDRFullPointerField(
             NDRPacketField(
-                "fileScreenTemplateNamesArray", wireVARIANTStr(), wireVARIANTStr
+                "serializedFileScreenTemplates", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField(
+                    "fileScreenTemplateNamesArray", wireVARIANTStr(), wireVARIANTStr
+                )
             )
         ),
     ]

--- a/scapy-rpc/msrpcs/ms_iiss.py
+++ b/scapy-rpc/msrpcs/ms_iiss.py
@@ -1012,12 +1012,14 @@ class Invoke_Request(NDRPacket):
         NDRConfFieldListField(
             "rgVarRefIdx", [], NDRIntField("", 0), size_is=lambda pkt: pkt.cVarRef
         ),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
     ]
 
@@ -1025,16 +1027,20 @@ class Invoke_Request(NDRPacket):
 class Invoke_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRPacketField("pExcepInfo", EXCEPINFO(), EXCEPINFO),
         NDRIntField("pArgErr", 0),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
         NDRIntField("status", 0),
     ]

--- a/scapy-rpc/msrpcs/ms_imsa.py
+++ b/scapy-rpc/msrpcs/ms_imsa.py
@@ -1012,7 +1012,9 @@ class EnumerateApplicationsInPool_Request(NDRPacket):
 class EnumerateApplicationsInPool_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("bstrBuffer", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("bstrBuffer", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1978,12 +1980,14 @@ class Invoke_Request(NDRPacket):
         NDRConfFieldListField(
             "rgVarRefIdx", [], NDRIntField("", 0), size_is=lambda pkt: pkt.cVarRef
         ),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
     ]
 
@@ -1991,16 +1995,20 @@ class Invoke_Request(NDRPacket):
 class Invoke_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRPacketField("pExcepInfo", EXCEPINFO(), EXCEPINFO),
         NDRIntField("pArgErr", 0),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2046,7 +2054,11 @@ class put_IIISCertObj_Opnum9NotUsedOnWire_Response(NDRPacket):
 
 
 class put_IIISCertObj_InstanceName_Request(NDRPacket):
-    fields_desc = [NDRPacketField("newVal", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("newVal", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IIISCertObj_InstanceName_Response(NDRPacket):
@@ -2076,7 +2088,9 @@ class GetCertInfoRemote_Request(NDRPacket):
 class GetCertInfoRemote_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("BinaryVariant", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("BinaryVariant", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2084,8 +2098,12 @@ class GetCertInfoRemote_Response(NDRPacket):
 
 class ImportFromBlob_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("InstanceName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("Password", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("InstanceName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("Password", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedShortField("bInstallToMetabase", 0),
         NDRSignedShortField("bAllowExport", 0),
         NDRSignedShortField("bOverWriteExisting", 0),
@@ -2100,8 +2118,12 @@ class ImportFromBlob_Response(NDRPacket):
 
 class ImportFromBlobGetHash_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("InstanceName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("Password", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("InstanceName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("Password", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedShortField("bInstallToMetabase", 0),
         NDRSignedShortField("bAllowExport", 0),
         NDRSignedShortField("bOverWriteExisting", 0),
@@ -2120,8 +2142,12 @@ class ImportFromBlobGetHash_Response(NDRPacket):
 
 class ExportToBlob_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("InstanceName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("Password", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("InstanceName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("Password", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedShortField("bPrivateKey", 0),
         NDRSignedShortField("bCertChain", 0),
         NDRIntField("pcbSize", 0),

--- a/scapy-rpc/msrpcs/ms_ioi.py
+++ b/scapy-rpc/msrpcs/ms_ioi.py
@@ -77,7 +77,9 @@ class GetSerializedBuffer_Request(NDRPacket):
 class GetSerializedBuffer_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pBSTR", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pBSTR", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -90,7 +92,9 @@ class GetObjectIdentity_Request(NDRPacket):
 class GetObjectIdentity_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pBSTRGUID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pBSTRGUID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRSignedIntField("AppDomainID", 0),
         NDRSignedIntField("pCCW", 0),
@@ -1055,12 +1059,14 @@ class Invoke_Request(NDRPacket):
         NDRConfFieldListField(
             "rgVarRefIdx", [], NDRIntField("", 0), size_is=lambda pkt: pkt.cVarRef
         ),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
     ]
 
@@ -1068,16 +1074,20 @@ class Invoke_Request(NDRPacket):
 class Invoke_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRPacketField("pExcepInfo", EXCEPINFO(), EXCEPINFO),
         NDRIntField("pArgErr", 0),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1099,26 +1109,34 @@ register_com_interface(
 
 
 class RemoteDispatchAutoDone_Request(NDRPacket):
-    fields_desc = [NDRPacketField("s", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("s", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB))
+    ]
 
 
 class RemoteDispatchAutoDone_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pRetVal", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pRetVal", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class RemoteDispatchNotAutoDone_Request(NDRPacket):
-    fields_desc = [NDRPacketField("s", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("s", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB))
+    ]
 
 
 class RemoteDispatchNotAutoDone_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pRetVal", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pRetVal", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1148,7 +1166,9 @@ class GetComponentInfo_Request(NDRPacket):
 class GetComponentInfo_Response(NDRPacket):
     fields_desc = [
         NDRSignedIntField("infoMask", 0),
-        NDRFullPointerField(NDRPacketField("infoArray", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("infoArray", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 

--- a/scapy-rpc/msrpcs/ms_lsad.py
+++ b/scapy-rpc/msrpcs/ms_lsad.py
@@ -32,6 +32,7 @@ from scapy.layers.dcerpc import (
     NDRInt3264EnumField,
     NDRIntField,
     NDRPacketField,
+    NDRRefEmbPointerField,
     NDRShortField,
     NDRSignedIntField,
     NDRSignedLongField,
@@ -947,7 +948,7 @@ class LsarSetInformationPolicy_Response(NDRPacket):
 class LsarCreateAccount_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("PolicyHandle", NDRContextHandle(), NDRContextHandle),
-        NDRPacketField("AccountSid", PRPC_SID(), PRPC_SID),
+        NDRFullPointerField(NDRPacketField("AccountSid", PRPC_SID(), PRPC_SID)),
         NDRIntField("DesiredAccess", 0),
     ]
 
@@ -1030,7 +1031,7 @@ class PLSAPR_TRUSTED_ENUM_BUFFER(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
         NDRIntField("EntriesRead", None, size_of="Information"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "Information",
                 [],
@@ -1097,7 +1098,7 @@ class LsarCreateSecret_Response(NDRPacket):
 class LsarOpenAccount_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("PolicyHandle", NDRContextHandle(), NDRContextHandle),
-        NDRPacketField("AccountSid", PRPC_SID(), PRPC_SID),
+        NDRFullPointerField(NDRPacketField("AccountSid", PRPC_SID(), PRPC_SID)),
         NDRIntField("DesiredAccess", 0),
     ]
 
@@ -1160,9 +1161,7 @@ class LsarRemovePrivilegesFromAccount_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("AccountHandle", NDRContextHandle(), NDRContextHandle),
         NDRByteField("AllPrivileges", 0),
-        NDRFullPointerField(
-            NDRPacketField("Privileges", PLSAPR_PRIVILEGE_SET(), PLSAPR_PRIVILEGE_SET)
-        ),
+        NDRPacketField("Privileges", PLSAPR_PRIVILEGE_SET(), PLSAPR_PRIVILEGE_SET),
     ]
 
 
@@ -1194,7 +1193,7 @@ class LsarSetSystemAccessAccount_Response(NDRPacket):
 class LsarOpenTrustedDomain_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("PolicyHandle", NDRContextHandle(), NDRContextHandle),
-        NDRPacketField("TrustedDomainSid", PRPC_SID(), PRPC_SID),
+        NDRFullPointerField(NDRPacketField("TrustedDomainSid", PRPC_SID(), PRPC_SID)),
         NDRIntField("DesiredAccess", 0),
     ]
 
@@ -1233,7 +1232,7 @@ class LSAPR_TRUSTED_CONTROLLERS_INFO(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
         NDRIntField("Entries", None, size_of="Names"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "Names", [], PRPC_UNICODE_STRING, size_is=lambda pkt: pkt.Entries
             )
@@ -2078,9 +2077,7 @@ class LsarQuerySecret_Request(NDRPacket):
                 )
             )
         ),
-        NDRFullPointerField(
-            NDRPacketField("CurrentValueSetTime", PLARGE_INTEGER(), PLARGE_INTEGER)
-        ),
+        NDRPacketField("CurrentValueSetTime", PLARGE_INTEGER(), PLARGE_INTEGER),
         NDRFullPointerField(
             NDRFullPointerField(
                 NDRPacketField(
@@ -2090,9 +2087,7 @@ class LsarQuerySecret_Request(NDRPacket):
                 )
             )
         ),
-        NDRFullPointerField(
-            NDRPacketField("OldValueSetTime", PLARGE_INTEGER(), PLARGE_INTEGER)
-        ),
+        NDRPacketField("OldValueSetTime", PLARGE_INTEGER(), PLARGE_INTEGER),
     ]
 
 
@@ -2107,9 +2102,7 @@ class LsarQuerySecret_Response(NDRPacket):
                 )
             )
         ),
-        NDRFullPointerField(
-            NDRPacketField("CurrentValueSetTime", PLARGE_INTEGER(), PLARGE_INTEGER)
-        ),
+        NDRPacketField("CurrentValueSetTime", PLARGE_INTEGER(), PLARGE_INTEGER),
         NDRFullPointerField(
             NDRFullPointerField(
                 NDRPacketField(
@@ -2119,9 +2112,7 @@ class LsarQuerySecret_Response(NDRPacket):
                 )
             )
         ),
-        NDRFullPointerField(
-            NDRPacketField("OldValueSetTime", PLARGE_INTEGER(), PLARGE_INTEGER)
-        ),
+        NDRPacketField("OldValueSetTime", PLARGE_INTEGER(), PLARGE_INTEGER),
         NDRIntField("status", 0),
     ]
 
@@ -2191,9 +2182,7 @@ class LsarDeleteObject_Response(NDRPacket):
 class LsarEnumerateAccountsWithUserRight_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("PolicyHandle", NDRContextHandle(), NDRContextHandle),
-        NDRFullPointerField(
-            NDRPacketField("UserRight", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING)
-        ),
+        NDRPacketField("UserRight", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING),
     ]
 
 
@@ -2212,7 +2201,7 @@ class PLSAPR_USER_RIGHT_SET(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
         NDRIntField("Entries", None, size_of="UserRights"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "UserRights", [], PRPC_UNICODE_STRING, size_is=lambda pkt: pkt.Entries
             )
@@ -2223,7 +2212,7 @@ class PLSAPR_USER_RIGHT_SET(NDRPacket):
 class LsarEnumerateAccountRights_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("PolicyHandle", NDRContextHandle(), NDRContextHandle),
-        NDRPacketField("AccountSid", PRPC_SID(), PRPC_SID),
+        NDRFullPointerField(NDRPacketField("AccountSid", PRPC_SID(), PRPC_SID)),
     ]
 
 
@@ -2237,7 +2226,7 @@ class LsarEnumerateAccountRights_Response(NDRPacket):
 class LsarAddAccountRights_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("PolicyHandle", NDRContextHandle(), NDRContextHandle),
-        NDRPacketField("AccountSid", PRPC_SID(), PRPC_SID),
+        NDRFullPointerField(NDRPacketField("AccountSid", PRPC_SID(), PRPC_SID)),
         NDRPacketField("UserRights", PLSAPR_USER_RIGHT_SET(), PLSAPR_USER_RIGHT_SET),
     ]
 
@@ -2249,7 +2238,7 @@ class LsarAddAccountRights_Response(NDRPacket):
 class LsarRemoveAccountRights_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("PolicyHandle", NDRContextHandle(), NDRContextHandle),
-        NDRPacketField("AccountSid", PRPC_SID(), PRPC_SID),
+        NDRFullPointerField(NDRPacketField("AccountSid", PRPC_SID(), PRPC_SID)),
         NDRByteField("AllRights", 0),
         NDRPacketField("UserRights", PLSAPR_USER_RIGHT_SET(), PLSAPR_USER_RIGHT_SET),
     ]
@@ -2262,7 +2251,7 @@ class LsarRemoveAccountRights_Response(NDRPacket):
 class LsarQueryTrustedDomainInfo_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("PolicyHandle", NDRContextHandle(), NDRContextHandle),
-        NDRPacketField("TrustedDomainSid", PRPC_SID(), PRPC_SID),
+        NDRFullPointerField(NDRPacketField("TrustedDomainSid", PRPC_SID(), PRPC_SID)),
         NDRInt3264EnumField("InformationClass", 0, TRUSTED_INFORMATION_CLASS),
     ]
 
@@ -2540,7 +2529,7 @@ class LsarQueryTrustedDomainInfo_Response(NDRPacket):
 class LsarSetTrustedDomainInfo_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("PolicyHandle", NDRContextHandle(), NDRContextHandle),
-        NDRPacketField("TrustedDomainSid", PRPC_SID(), PRPC_SID),
+        NDRFullPointerField(NDRPacketField("TrustedDomainSid", PRPC_SID(), PRPC_SID)),
         NDRInt3264EnumField("InformationClass", 0, TRUSTED_INFORMATION_CLASS),
         NDRUnionField(
             [
@@ -2814,7 +2803,7 @@ class LsarSetTrustedDomainInfo_Response(NDRPacket):
 class LsarDeleteTrustedDomain_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("PolicyHandle", NDRContextHandle(), NDRContextHandle),
-        NDRPacketField("TrustedDomainSid", PRPC_SID(), PRPC_SID),
+        NDRFullPointerField(NDRPacketField("TrustedDomainSid", PRPC_SID(), PRPC_SID)),
     ]
 
 
@@ -2843,8 +2832,10 @@ class LsarRetrievePrivateData_Request(NDRPacket):
         NDRPacketField("PolicyHandle", NDRContextHandle(), NDRContextHandle),
         NDRPacketField("KeyName", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING),
         NDRFullPointerField(
-            NDRPacketField(
-                "EncryptedData", PLSAPR_CR_CIPHER_VALUE(), PLSAPR_CR_CIPHER_VALUE
+            NDRFullPointerField(
+                NDRPacketField(
+                    "EncryptedData", PLSAPR_CR_CIPHER_VALUE(), PLSAPR_CR_CIPHER_VALUE
+                )
             )
         ),
     ]
@@ -2853,8 +2844,10 @@ class LsarRetrievePrivateData_Request(NDRPacket):
 class LsarRetrievePrivateData_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "EncryptedData", PLSAPR_CR_CIPHER_VALUE(), PLSAPR_CR_CIPHER_VALUE
+            NDRFullPointerField(
+                NDRPacketField(
+                    "EncryptedData", PLSAPR_CR_CIPHER_VALUE(), PLSAPR_CR_CIPHER_VALUE
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -4032,10 +4025,12 @@ class PLSAPR_TRUSTED_DOMAIN_AUTH_INFORMATION(NDRPacket):
 class LsarCreateTrustedDomainEx_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("PolicyHandle", NDRContextHandle(), NDRContextHandle),
-        NDRPacketField(
-            "TrustedDomainInformation",
-            PLSAPR_TRUSTED_DOMAIN_INFORMATION_EX(),
-            PLSAPR_TRUSTED_DOMAIN_INFORMATION_EX,
+        NDRFullPointerField(
+            NDRPacketField(
+                "TrustedDomainInformation",
+                PLSAPR_TRUSTED_DOMAIN_INFORMATION_EX(),
+                PLSAPR_TRUSTED_DOMAIN_INFORMATION_EX,
+            )
         ),
         NDRPacketField(
             "AuthenticationInformation",
@@ -4163,65 +4158,63 @@ class LsarSetDomainInformationPolicy_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("PolicyHandle", NDRContextHandle(), NDRContextHandle),
         NDRInt3264EnumField("InformationClass", 0, POLICY_DOMAIN_INFORMATION_CLASS),
-        NDRFullPointerField(
-            NDRUnionField(
-                [
-                    (
-                        NDRPacketField(
-                            "PolicyDomainInformation",
-                            POLICY_DOMAIN_QUALITY_OF_SERVICE_INFO(),
-                            POLICY_DOMAIN_QUALITY_OF_SERVICE_INFO,
-                        ),
-                        (
-                            (
-                                lambda pkt: getattr(pkt, "InformationClass", None)
-                                == POLICY_DOMAIN_INFORMATION_CLASS.PolicyDomainQualityOfServiceInformation
-                            ),
-                            (
-                                lambda _, val: val.tag
-                                == POLICY_DOMAIN_INFORMATION_CLASS.PolicyDomainQualityOfServiceInformation
-                            ),
-                        ),
+        NDRUnionField(
+            [
+                (
+                    NDRPacketField(
+                        "PolicyDomainInformation",
+                        POLICY_DOMAIN_QUALITY_OF_SERVICE_INFO(),
+                        POLICY_DOMAIN_QUALITY_OF_SERVICE_INFO,
                     ),
                     (
-                        NDRPacketField(
-                            "PolicyDomainInformation",
-                            LSAPR_POLICY_DOMAIN_EFS_INFO(),
-                            LSAPR_POLICY_DOMAIN_EFS_INFO,
+                        (
+                            lambda pkt: getattr(pkt, "InformationClass", None)
+                            == POLICY_DOMAIN_INFORMATION_CLASS.PolicyDomainQualityOfServiceInformation
                         ),
                         (
-                            (
-                                lambda pkt: getattr(pkt, "InformationClass", None)
-                                == POLICY_DOMAIN_INFORMATION_CLASS.PolicyDomainEfsInformation
-                            ),
-                            (
-                                lambda _, val: val.tag
-                                == POLICY_DOMAIN_INFORMATION_CLASS.PolicyDomainEfsInformation
-                            ),
+                            lambda _, val: val.tag
+                            == POLICY_DOMAIN_INFORMATION_CLASS.PolicyDomainQualityOfServiceInformation
                         ),
+                    ),
+                ),
+                (
+                    NDRPacketField(
+                        "PolicyDomainInformation",
+                        LSAPR_POLICY_DOMAIN_EFS_INFO(),
+                        LSAPR_POLICY_DOMAIN_EFS_INFO,
                     ),
                     (
-                        NDRPacketField(
-                            "PolicyDomainInformation",
-                            POLICY_DOMAIN_KERBEROS_TICKET_INFO(),
-                            POLICY_DOMAIN_KERBEROS_TICKET_INFO,
+                        (
+                            lambda pkt: getattr(pkt, "InformationClass", None)
+                            == POLICY_DOMAIN_INFORMATION_CLASS.PolicyDomainEfsInformation
                         ),
                         (
-                            (
-                                lambda pkt: getattr(pkt, "InformationClass", None)
-                                == POLICY_DOMAIN_INFORMATION_CLASS.PolicyDomainKerberosTicketInformation
-                            ),
-                            (
-                                lambda _, val: val.tag
-                                == POLICY_DOMAIN_INFORMATION_CLASS.PolicyDomainKerberosTicketInformation
-                            ),
+                            lambda _, val: val.tag
+                            == POLICY_DOMAIN_INFORMATION_CLASS.PolicyDomainEfsInformation
                         ),
                     ),
-                ],
-                StrFixedLenField("PolicyDomainInformation", "", length=0),
-                align=(2, 8),
-                switch_fmt=("H", "I"),
-            )
+                ),
+                (
+                    NDRPacketField(
+                        "PolicyDomainInformation",
+                        POLICY_DOMAIN_KERBEROS_TICKET_INFO(),
+                        POLICY_DOMAIN_KERBEROS_TICKET_INFO,
+                    ),
+                    (
+                        (
+                            lambda pkt: getattr(pkt, "InformationClass", None)
+                            == POLICY_DOMAIN_INFORMATION_CLASS.PolicyDomainKerberosTicketInformation
+                        ),
+                        (
+                            lambda _, val: val.tag
+                            == POLICY_DOMAIN_INFORMATION_CLASS.PolicyDomainKerberosTicketInformation
+                        ),
+                    ),
+                ),
+            ],
+            StrFixedLenField("PolicyDomainInformation", "", length=0),
+            align=(2, 8),
+            switch_fmt=("H", "I"),
         ),
     ]
 
@@ -4257,10 +4250,12 @@ class PLSAPR_TRUSTED_DOMAIN_AUTH_INFORMATION_INTERNAL(NDRPacket):
 class LsarCreateTrustedDomainEx2_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("PolicyHandle", NDRContextHandle(), NDRContextHandle),
-        NDRPacketField(
-            "TrustedDomainInformation",
-            PLSAPR_TRUSTED_DOMAIN_INFORMATION_EX(),
-            PLSAPR_TRUSTED_DOMAIN_INFORMATION_EX,
+        NDRFullPointerField(
+            NDRPacketField(
+                "TrustedDomainInformation",
+                PLSAPR_TRUSTED_DOMAIN_INFORMATION_EX(),
+                PLSAPR_TRUSTED_DOMAIN_INFORMATION_EX,
+            )
         ),
         NDRPacketField(
             "AuthenticationInformation",
@@ -4501,10 +4496,12 @@ class PLSAPR_TRUSTED_DOMAIN_AUTH_INFORMATION_INTERNAL_AES(NDRPacket):
 class LsarCreateTrustedDomainEx3_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("PolicyHandle", NDRContextHandle(), NDRContextHandle),
-        NDRPacketField(
-            "TrustedDomainInformation",
-            PLSAPR_TRUSTED_DOMAIN_INFORMATION_EX(),
-            PLSAPR_TRUSTED_DOMAIN_INFORMATION_EX,
+        NDRFullPointerField(
+            NDRPacketField(
+                "TrustedDomainInformation",
+                PLSAPR_TRUSTED_DOMAIN_INFORMATION_EX(),
+                PLSAPR_TRUSTED_DOMAIN_INFORMATION_EX,
+            )
         ),
         NDRPacketField(
             "AuthenticationInformation",
@@ -4837,17 +4834,11 @@ class LsarCreateSecret2_Response(NDRPacket):
 class LsarSetSecret2_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("SecretHandle", NDRContextHandle(), NDRContextHandle),
-        NDRFullPointerField(
-            NDRPacketField(
-                "EncryptedCurrentValue",
-                PLSAPR_AES_CIPHER_VALUE(),
-                PLSAPR_AES_CIPHER_VALUE,
-            )
+        NDRPacketField(
+            "EncryptedCurrentValue", PLSAPR_AES_CIPHER_VALUE(), PLSAPR_AES_CIPHER_VALUE
         ),
-        NDRFullPointerField(
-            NDRPacketField(
-                "EncryptedOldValue", PLSAPR_AES_CIPHER_VALUE(), PLSAPR_AES_CIPHER_VALUE
-            )
+        NDRPacketField(
+            "EncryptedOldValue", PLSAPR_AES_CIPHER_VALUE(), PLSAPR_AES_CIPHER_VALUE
         ),
     ]
 
@@ -4860,58 +4851,38 @@ class LsarQuerySecret2_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("SecretHandle", NDRContextHandle(), NDRContextHandle),
         NDRFullPointerField(
-            NDRFullPointerField(
-                NDRPacketField(
-                    "EncryptedCurrentValue",
-                    PLSAPR_AES_CIPHER_VALUE(),
-                    PLSAPR_AES_CIPHER_VALUE,
-                )
+            NDRPacketField(
+                "EncryptedCurrentValue",
+                PLSAPR_AES_CIPHER_VALUE(),
+                PLSAPR_AES_CIPHER_VALUE,
             )
         ),
+        NDRPacketField("CurrentValueSetTime", PLARGE_INTEGER(), PLARGE_INTEGER),
         NDRFullPointerField(
-            NDRPacketField("CurrentValueSetTime", PLARGE_INTEGER(), PLARGE_INTEGER)
-        ),
-        NDRFullPointerField(
-            NDRFullPointerField(
-                NDRPacketField(
-                    "EncryptedOldValue",
-                    PLSAPR_AES_CIPHER_VALUE(),
-                    PLSAPR_AES_CIPHER_VALUE,
-                )
+            NDRPacketField(
+                "EncryptedOldValue", PLSAPR_AES_CIPHER_VALUE(), PLSAPR_AES_CIPHER_VALUE
             )
         ),
-        NDRFullPointerField(
-            NDRPacketField("OldValueSetTime", PLARGE_INTEGER(), PLARGE_INTEGER)
-        ),
+        NDRPacketField("OldValueSetTime", PLARGE_INTEGER(), PLARGE_INTEGER),
     ]
 
 
 class LsarQuerySecret2_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRFullPointerField(
-                NDRPacketField(
-                    "EncryptedCurrentValue",
-                    PLSAPR_AES_CIPHER_VALUE(),
-                    PLSAPR_AES_CIPHER_VALUE,
-                )
+            NDRPacketField(
+                "EncryptedCurrentValue",
+                PLSAPR_AES_CIPHER_VALUE(),
+                PLSAPR_AES_CIPHER_VALUE,
             )
         ),
+        NDRPacketField("CurrentValueSetTime", PLARGE_INTEGER(), PLARGE_INTEGER),
         NDRFullPointerField(
-            NDRPacketField("CurrentValueSetTime", PLARGE_INTEGER(), PLARGE_INTEGER)
-        ),
-        NDRFullPointerField(
-            NDRFullPointerField(
-                NDRPacketField(
-                    "EncryptedOldValue",
-                    PLSAPR_AES_CIPHER_VALUE(),
-                    PLSAPR_AES_CIPHER_VALUE,
-                )
+            NDRPacketField(
+                "EncryptedOldValue", PLSAPR_AES_CIPHER_VALUE(), PLSAPR_AES_CIPHER_VALUE
             )
         ),
-        NDRFullPointerField(
-            NDRPacketField("OldValueSetTime", PLARGE_INTEGER(), PLARGE_INTEGER)
-        ),
+        NDRPacketField("OldValueSetTime", PLARGE_INTEGER(), PLARGE_INTEGER),
         NDRIntField("status", 0),
     ]
 
@@ -4922,10 +4893,8 @@ class LsarStorePrivateData2_Request(NDRPacket):
         NDRPacketField(
             "EncryptedKeyName", PLSAPR_AES_CIPHER_VALUE(), PLSAPR_AES_CIPHER_VALUE
         ),
-        NDRFullPointerField(
-            NDRPacketField(
-                "EncryptedData", PLSAPR_AES_CIPHER_VALUE(), PLSAPR_AES_CIPHER_VALUE
-            )
+        NDRPacketField(
+            "EncryptedData", PLSAPR_AES_CIPHER_VALUE(), PLSAPR_AES_CIPHER_VALUE
         ),
     ]
 
@@ -4941,10 +4910,8 @@ class LsarRetrievePrivateData2_Request(NDRPacket):
             "EncryptedKeyName", PLSAPR_AES_CIPHER_VALUE(), PLSAPR_AES_CIPHER_VALUE
         ),
         NDRFullPointerField(
-            NDRFullPointerField(
-                NDRPacketField(
-                    "EncryptedData", PLSAPR_AES_CIPHER_VALUE(), PLSAPR_AES_CIPHER_VALUE
-                )
+            NDRPacketField(
+                "EncryptedData", PLSAPR_AES_CIPHER_VALUE(), PLSAPR_AES_CIPHER_VALUE
             )
         ),
     ]
@@ -4953,10 +4920,8 @@ class LsarRetrievePrivateData2_Request(NDRPacket):
 class LsarRetrievePrivateData2_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRFullPointerField(
-                NDRPacketField(
-                    "EncryptedData", PLSAPR_AES_CIPHER_VALUE(), PLSAPR_AES_CIPHER_VALUE
-                )
+            NDRPacketField(
+                "EncryptedData", PLSAPR_AES_CIPHER_VALUE(), PLSAPR_AES_CIPHER_VALUE
             )
         ),
         NDRIntField("status", 0),

--- a/scapy-rpc/msrpcs/ms_lsat.py
+++ b/scapy-rpc/msrpcs/ms_lsat.py
@@ -403,9 +403,7 @@ class LsarGetUserName_Request(NDRPacket):
             NDRPacketField("UserName", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING)
         ),
         NDRFullPointerField(
-            NDRFullPointerField(
-                NDRPacketField("DomainName", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING)
-            )
+            NDRPacketField("DomainName", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING)
         ),
     ]
 
@@ -416,9 +414,7 @@ class LsarGetUserName_Response(NDRPacket):
             NDRPacketField("UserName", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING)
         ),
         NDRFullPointerField(
-            NDRFullPointerField(
-                NDRPacketField("DomainName", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING)
-            )
+            NDRPacketField("DomainName", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING)
         ),
         NDRIntField("status", 0),
     ]

--- a/scapy-rpc/msrpcs/ms_nrpc.py
+++ b/scapy-rpc/msrpcs/ms_nrpc.py
@@ -33,6 +33,7 @@ from scapy.layers.dcerpc import (
     NDRIntField,
     NDRLongField,
     NDRPacketField,
+    NDRRefEmbPointerField,
     NDRShortField,
     NDRSignedIntField,
     NDRSignedLongField,
@@ -523,17 +524,11 @@ class NetrLogonSamLogon_Request(NDRPacket):
     fields_desc = [
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("LogonServer", "")),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("ComputerName", "")),
-        NDRFullPointerField(
-            NDRPacketField(
-                "Authenticator", PNETLOGON_AUTHENTICATOR(), PNETLOGON_AUTHENTICATOR
-            )
+        NDRPacketField(
+            "Authenticator", PNETLOGON_AUTHENTICATOR(), PNETLOGON_AUTHENTICATOR
         ),
-        NDRFullPointerField(
-            NDRPacketField(
-                "ReturnAuthenticator",
-                PNETLOGON_AUTHENTICATOR(),
-                PNETLOGON_AUTHENTICATOR,
-            )
+        NDRPacketField(
+            "ReturnAuthenticator", PNETLOGON_AUTHENTICATOR(), PNETLOGON_AUTHENTICATOR
         ),
         NDRInt3264EnumField("LogonLevel", 0, NETLOGON_LOGON_INFO_CLASS),
         NDRUnionField(
@@ -701,12 +696,8 @@ class NetrLogonSamLogon_Request(NDRPacket):
 
 class NetrLogonSamLogon_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(
-            NDRPacketField(
-                "ReturnAuthenticator",
-                PNETLOGON_AUTHENTICATOR(),
-                PNETLOGON_AUTHENTICATOR,
-            )
+        NDRPacketField(
+            "ReturnAuthenticator", PNETLOGON_AUTHENTICATOR(), PNETLOGON_AUTHENTICATOR
         ),
         NDRUnionField(
             [
@@ -819,17 +810,11 @@ class NetrLogonSamLogoff_Request(NDRPacket):
     fields_desc = [
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("LogonServer", "")),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("ComputerName", "")),
-        NDRFullPointerField(
-            NDRPacketField(
-                "Authenticator", PNETLOGON_AUTHENTICATOR(), PNETLOGON_AUTHENTICATOR
-            )
+        NDRPacketField(
+            "Authenticator", PNETLOGON_AUTHENTICATOR(), PNETLOGON_AUTHENTICATOR
         ),
-        NDRFullPointerField(
-            NDRPacketField(
-                "ReturnAuthenticator",
-                PNETLOGON_AUTHENTICATOR(),
-                PNETLOGON_AUTHENTICATOR,
-            )
+        NDRPacketField(
+            "ReturnAuthenticator", PNETLOGON_AUTHENTICATOR(), PNETLOGON_AUTHENTICATOR
         ),
         NDRInt3264EnumField("LogonLevel", 0, NETLOGON_LOGON_INFO_CLASS),
         NDRUnionField(
@@ -996,12 +981,8 @@ class NetrLogonSamLogoff_Request(NDRPacket):
 
 class NetrLogonSamLogoff_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(
-            NDRPacketField(
-                "ReturnAuthenticator",
-                PNETLOGON_AUTHENTICATOR(),
-                PNETLOGON_AUTHENTICATOR,
-            )
+        NDRPacketField(
+            "ReturnAuthenticator", PNETLOGON_AUTHENTICATOR(), PNETLOGON_AUTHENTICATOR
         ),
         NDRIntField("status", 0),
     ]
@@ -1993,7 +1974,7 @@ class PNETLOGON_DELTA_ENUM(NDRPacket):
                     ),
                 ),
                 (
-                    NDRFullEmbPointerField(
+                    NDRRefEmbPointerField(
                         NDRPacketField(
                             "DeltaUnion", PNLPR_MODIFIED_COUNT(), PNLPR_MODIFIED_COUNT
                         )
@@ -3750,17 +3731,11 @@ class NetrLogonSamLogonWithFlags_Request(NDRPacket):
     fields_desc = [
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("LogonServer", "")),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("ComputerName", "")),
-        NDRFullPointerField(
-            NDRPacketField(
-                "Authenticator", PNETLOGON_AUTHENTICATOR(), PNETLOGON_AUTHENTICATOR
-            )
+        NDRPacketField(
+            "Authenticator", PNETLOGON_AUTHENTICATOR(), PNETLOGON_AUTHENTICATOR
         ),
-        NDRFullPointerField(
-            NDRPacketField(
-                "ReturnAuthenticator",
-                PNETLOGON_AUTHENTICATOR(),
-                PNETLOGON_AUTHENTICATOR,
-            )
+        NDRPacketField(
+            "ReturnAuthenticator", PNETLOGON_AUTHENTICATOR(), PNETLOGON_AUTHENTICATOR
         ),
         NDRInt3264EnumField("LogonLevel", 0, NETLOGON_LOGON_INFO_CLASS),
         NDRUnionField(
@@ -3929,12 +3904,8 @@ class NetrLogonSamLogonWithFlags_Request(NDRPacket):
 
 class NetrLogonSamLogonWithFlags_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(
-            NDRPacketField(
-                "ReturnAuthenticator",
-                PNETLOGON_AUTHENTICATOR(),
-                PNETLOGON_AUTHENTICATOR,
-            )
+        NDRPacketField(
+            "ReturnAuthenticator", PNETLOGON_AUTHENTICATOR(), PNETLOGON_AUTHENTICATOR
         ),
         NDRUnionField(
             [

--- a/scapy-rpc/msrpcs/ms_oaut.py
+++ b/scapy-rpc/msrpcs/ms_oaut.py
@@ -1022,12 +1022,14 @@ class Invoke_Request(NDRPacket):
         NDRConfFieldListField(
             "rgVarRefIdx", [], NDRIntField("", 0), size_is=lambda pkt: pkt.cVarRef
         ),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
     ]
 
@@ -1035,16 +1037,20 @@ class Invoke_Request(NDRPacket):
 class Invoke_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRPacketField("pExcepInfo", EXCEPINFO(), EXCEPINFO),
         NDRIntField("pArgErr", 0),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1167,14 +1173,20 @@ class GetDocumentation_Request(NDRPacket):
 class GetDocumentation_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pBstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pBstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRFullPointerField(
-            NDRPacketField("pBstrDocString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pBstrDocString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("pdwHelpContext", 0),
         NDRFullPointerField(
-            NDRPacketField("pBstrHelpFile", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pBstrHelpFile", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1191,7 +1203,11 @@ class IsName_Response(NDRPacket):
     fields_desc = [
         NDRSignedIntField("pfName", 0),
         NDRFullPointerField(
-            NDRPacketField("pBstrNameInLibrary", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pBstrNameInLibrary", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1224,7 +1240,11 @@ class FindName_Response(NDRPacket):
         ),
         NDRShortField("pcFound", None, size_of="rgMemId"),
         NDRFullPointerField(
-            NDRPacketField("pBstrNameInLibrary", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pBstrNameInLibrary", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1531,13 +1551,15 @@ class GetNames_Request(NDRPacket):
 
 class GetNames_Response(NDRPacket):
     fields_desc = [
-        NDRConfVarPacketListField(
-            "rgBstrNames",
-            [],
-            FLAGGED_WORD_BLOB,
-            size_is=lambda pkt: pkt.cMaxNames,
-            length_is=lambda pkt: pkt.pcNames,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfVarPacketListField(
+                "rgBstrNames",
+                [],
+                FLAGGED_WORD_BLOB,
+                size_is=lambda pkt: pkt.cMaxNames,
+                length_is=lambda pkt: pkt.pcNames,
+                ptr_pack=True,
+            )
         ),
         NDRIntField("pcNames", None, size_of="rgBstrNames"),
         NDRIntField("status", 0),
@@ -1567,14 +1589,20 @@ class GetDocumentation_Request(NDRPacket):
 class GetDocumentation_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pBstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pBstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRFullPointerField(
-            NDRPacketField("pBstrDocString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pBstrDocString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("pdwHelpContext", 0),
         NDRFullPointerField(
-            NDRPacketField("pBstrHelpFile", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pBstrHelpFile", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1591,10 +1619,14 @@ class GetDllEntry_Request(NDRPacket):
 class GetDllEntry_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pBstrDllName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pBstrDllName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRFullPointerField(
-            NDRPacketField("pBstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pBstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRShortField("pwOrdinal", 0),
         NDRIntField("status", 0),
@@ -1634,7 +1666,9 @@ class GetMops_Request(NDRPacket):
 class GetMops_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pBstrMops", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pBstrMops", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1690,13 +1724,15 @@ class Next_Request(NDRPacket):
 
 class Next_Response(NDRPacket):
     fields_desc = [
-        NDRConfVarPacketListField(
-            "rgVar",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.celt,
-            length_is=lambda pkt: pkt.pCeltFetched,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfVarPacketListField(
+                "rgVar",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.celt,
+                length_is=lambda pkt: pkt.pCeltFetched,
+                ptr_pack=True,
+            )
         ),
         NDRIntField("pCeltFetched", None, size_of="rgVar"),
         NDRIntField("status", 0),
@@ -1850,7 +1886,9 @@ class GetCustData_Request(NDRPacket):
 class GetCustData_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pVarVal", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVarVal", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1863,7 +1901,9 @@ class GetFuncCustData_Request(NDRPacket):
 class GetFuncCustData_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pVarVal", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVarVal", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1880,7 +1920,9 @@ class GetParamCustData_Request(NDRPacket):
 class GetParamCustData_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pVarVal", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVarVal", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1893,7 +1935,9 @@ class GetVarCustData_Request(NDRPacket):
 class GetVarCustData_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pVarVal", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVarVal", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1906,7 +1950,9 @@ class GetImplTypeCustData_Request(NDRPacket):
 class GetImplTypeCustData_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pVarVal", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVarVal", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1923,11 +1969,19 @@ class GetDocumentation2_Request(NDRPacket):
 class GetDocumentation2_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrHelpString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrHelpString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("pdwHelpStringContext", 0),
         NDRFullPointerField(
-            NDRPacketField("pbstrHelpStringDll", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrHelpStringDll", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2062,7 +2116,9 @@ class GetCustData_Request(NDRPacket):
 class GetCustData_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pVarVal", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVarVal", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2091,11 +2147,19 @@ class GetDocumentation2_Request(NDRPacket):
 class GetDocumentation2_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrHelpString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrHelpString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("pdwHelpStringContext", 0),
         NDRFullPointerField(
-            NDRPacketField("pbstrHelpStringDll", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrHelpStringDll", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]

--- a/scapy-rpc/msrpcs/ms_pac.py
+++ b/scapy-rpc/msrpcs/ms_pac.py
@@ -29,6 +29,7 @@ from scapy.layers.dcerpc import (
     NDRIntField,
     NDRLongField,
     NDRPacketField,
+    NDRRefEmbPointerField,
     NDRShortField,
 )
 
@@ -95,7 +96,7 @@ class PDOMAIN_GROUP_MEMBERSHIP(NDRPacket):
             NDRFullEmbPointerField(NDRPacketField("DomainId", PSID(), PSID))
         ),
         NDRIntField("GroupCount", None, size_of="GroupIds"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "GroupIds", [], PGROUP_MEMBERSHIP, size_is=lambda pkt: pkt.GroupCount
             )
@@ -110,7 +111,7 @@ class PDOMAIN_GROUP_MEMBERSHIP(NDRPacket):
             NDRFullEmbPointerField(NDRPacketField("DomainId", PSID(), PSID))
         ),
         NDRIntField("GroupCount", None, size_of="GroupIds"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "GroupIds", [], PGROUP_MEMBERSHIP, size_is=lambda pkt: pkt.GroupCount
             )
@@ -213,7 +214,7 @@ class KERB_VALIDATION_INFO(NDRPacket):
         NDRIntField("UserId", 0),
         NDRIntField("PrimaryGroupId", 0),
         NDRIntField("GroupCount", None, size_of="GroupIds"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "GroupIds", [], PGROUP_MEMBERSHIP, size_is=lambda pkt: pkt.GroupCount
             )
@@ -233,7 +234,7 @@ class KERB_VALIDATION_INFO(NDRPacket):
             "Reserved3", [0] * 7, NDRIntField("", 0), length_is=lambda _: 7
         ),
         NDRIntField("SidCount", None, size_of="ExtraSids"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "ExtraSids",
                 [],
@@ -247,7 +248,7 @@ class KERB_VALIDATION_INFO(NDRPacket):
             )
         ),
         NDRIntField("ResourceGroupCount", None, size_of="ResourceGroupIds"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "ResourceGroupIds",
                 [],
@@ -278,7 +279,7 @@ class PKERB_VALIDATION_INFO(NDRPacket):
         NDRIntField("UserId", 0),
         NDRIntField("PrimaryGroupId", 0),
         NDRIntField("GroupCount", None, size_of="GroupIds"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "GroupIds", [], PGROUP_MEMBERSHIP, size_is=lambda pkt: pkt.GroupCount
             )
@@ -298,7 +299,7 @@ class PKERB_VALIDATION_INFO(NDRPacket):
             "Reserved3", [0] * 7, NDRIntField("", 0), length_is=lambda _: 7
         ),
         NDRIntField("SidCount", None, size_of="ExtraSids"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "ExtraSids",
                 [],
@@ -312,7 +313,7 @@ class PKERB_VALIDATION_INFO(NDRPacket):
             )
         ),
         NDRIntField("ResourceGroupCount", None, size_of="ResourceGroupIds"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "ResourceGroupIds",
                 [],
@@ -560,7 +561,7 @@ class PAC_DEVICE_INFO(NDRPacket):
             NDRFullEmbPointerField(NDRPacketField("AccountDomainId", PSID(), PSID))
         ),
         NDRIntField("AccountGroupCount", None, size_of="AccountGroupIds"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "AccountGroupIds",
                 [],
@@ -569,7 +570,7 @@ class PAC_DEVICE_INFO(NDRPacket):
             )
         ),
         NDRIntField("SidCount", None, size_of="ExtraSids"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "ExtraSids",
                 [],
@@ -578,7 +579,7 @@ class PAC_DEVICE_INFO(NDRPacket):
             )
         ),
         NDRIntField("DomainGroupCount", None, size_of="DomainGroup"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "DomainGroup",
                 [],
@@ -598,7 +599,7 @@ class PPAC_DEVICE_INFO(NDRPacket):
             NDRFullEmbPointerField(NDRPacketField("AccountDomainId", PSID(), PSID))
         ),
         NDRIntField("AccountGroupCount", None, size_of="AccountGroupIds"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "AccountGroupIds",
                 [],
@@ -607,7 +608,7 @@ class PPAC_DEVICE_INFO(NDRPacket):
             )
         ),
         NDRIntField("SidCount", None, size_of="ExtraSids"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "ExtraSids",
                 [],
@@ -616,7 +617,7 @@ class PPAC_DEVICE_INFO(NDRPacket):
             )
         ),
         NDRIntField("DomainGroupCount", None, size_of="DomainGroup"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "DomainGroup",
                 [],

--- a/scapy-rpc/msrpcs/ms_pla.py
+++ b/scapy-rpc/msrpcs/ms_pla.py
@@ -1030,12 +1030,14 @@ class Invoke_Request(NDRPacket):
         NDRConfFieldListField(
             "rgVarRefIdx", [], NDRIntField("", 0), size_is=lambda pkt: pkt.cVarRef
         ),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
     ]
 
@@ -1043,16 +1045,20 @@ class Invoke_Request(NDRPacket):
 class Invoke_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRPacketField("pExcepInfo", EXCEPINFO(), EXCEPINFO),
         NDRIntField("pArgErr", 0),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1109,7 +1115,9 @@ class get_IDataCollectorSet_Description_Request(NDRPacket):
 class get_IDataCollectorSet_Description_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("description", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("description", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1117,7 +1125,9 @@ class get_IDataCollectorSet_Description_Response(NDRPacket):
 
 class put_IDataCollectorSet_Description_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("description", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("description", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1132,7 +1142,9 @@ class get_IDataCollectorSet_DescriptionUnresolved_Request(NDRPacket):
 class get_IDataCollectorSet_DescriptionUnresolved_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("Descr", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("Descr", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1145,7 +1157,9 @@ class get_IDataCollectorSet_DisplayName_Request(NDRPacket):
 class get_IDataCollectorSet_DisplayName_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("DisplayName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("DisplayName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1153,7 +1167,9 @@ class get_IDataCollectorSet_DisplayName_Response(NDRPacket):
 
 class put_IDataCollectorSet_DisplayName_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("DisplayName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("DisplayName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1168,7 +1184,9 @@ class get_IDataCollectorSet_DisplayNameUnresolved_Request(NDRPacket):
 class get_IDataCollectorSet_DisplayNameUnresolved_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1180,13 +1198,17 @@ class get_IDataCollectorSet_Keywords_Request(NDRPacket):
 
 class get_IDataCollectorSet_Keywords_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("keywords", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("keywords", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IDataCollectorSet_Keywords_Request(NDRPacket):
-    fields_desc = [NDRPacketField("keywords", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("keywords", SAFEARRAY(), SAFEARRAY))
+    ]
 
 
 class put_IDataCollectorSet_Keywords_Response(NDRPacket):
@@ -1200,14 +1222,20 @@ class get_IDataCollectorSet_LatestOutputLocation_Request(NDRPacket):
 class get_IDataCollectorSet_LatestOutputLocation_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IDataCollectorSet_LatestOutputLocation_Request(NDRPacket):
-    fields_desc = [NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IDataCollectorSet_LatestOutputLocation_Response(NDRPacket):
@@ -1221,7 +1249,9 @@ class get_IDataCollectorSet_Name_Request(NDRPacket):
 class get_IDataCollectorSet_Name_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1234,7 +1264,9 @@ class get_IDataCollectorSet_OutputLocation_Request(NDRPacket):
 class get_IDataCollectorSet_OutputLocation_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1247,14 +1279,20 @@ class get_IDataCollectorSet_RootPath_Request(NDRPacket):
 class get_IDataCollectorSet_RootPath_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("folder", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("folder", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IDataCollectorSet_RootPath_Request(NDRPacket):
-    fields_desc = [NDRPacketField("folder", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("folder", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IDataCollectorSet_RootPath_Response(NDRPacket):
@@ -1332,7 +1370,9 @@ class get_IDataCollectorSet_Server_Request(NDRPacket):
 class get_IDataCollectorSet_Server_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("server", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("server", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1364,14 +1404,20 @@ class get_IDataCollectorSet_Subdirectory_Request(NDRPacket):
 class get_IDataCollectorSet_Subdirectory_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("folder", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("folder", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IDataCollectorSet_Subdirectory_Request(NDRPacket):
-    fields_desc = [NDRPacketField("folder", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("folder", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IDataCollectorSet_Subdirectory_Response(NDRPacket):
@@ -1417,14 +1463,20 @@ class get_IDataCollectorSet_SubdirectoryFormatPattern_Request(NDRPacket):
 class get_IDataCollectorSet_SubdirectoryFormatPattern_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pattern", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pattern", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IDataCollectorSet_SubdirectoryFormatPattern_Request(NDRPacket):
-    fields_desc = [NDRPacketField("pattern", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("pattern", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IDataCollectorSet_SubdirectoryFormatPattern_Response(NDRPacket):
@@ -1438,14 +1490,20 @@ class get_IDataCollectorSet_Task_Request(NDRPacket):
 class get_IDataCollectorSet_Task_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("task", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("task", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IDataCollectorSet_Task_Request(NDRPacket):
-    fields_desc = [NDRPacketField("task", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("task", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IDataCollectorSet_Task_Response(NDRPacket):
@@ -1475,14 +1533,20 @@ class get_IDataCollectorSet_TaskArguments_Request(NDRPacket):
 class get_IDataCollectorSet_TaskArguments_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("task", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("task", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IDataCollectorSet_TaskArguments_Request(NDRPacket):
-    fields_desc = [NDRPacketField("task", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("task", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IDataCollectorSet_TaskArguments_Response(NDRPacket):
@@ -1496,14 +1560,20 @@ class get_IDataCollectorSet_TaskUserTextArguments_Request(NDRPacket):
 class get_IDataCollectorSet_TaskUserTextArguments_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("UserText", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("UserText", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IDataCollectorSet_TaskUserTextArguments_Request(NDRPacket):
-    fields_desc = [NDRPacketField("UserText", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("UserText", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IDataCollectorSet_TaskUserTextArguments_Response(NDRPacket):
@@ -1546,7 +1616,9 @@ class get_IDataCollectorSet_UserAccount_Request(NDRPacket):
 class get_IDataCollectorSet_UserAccount_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("user", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("user", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1559,7 +1631,9 @@ class get_IDataCollectorSet_Xml_Request(NDRPacket):
 class get_IDataCollectorSet_Xml_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("xml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("xml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1572,7 +1646,9 @@ class get_IDataCollectorSet_Security_Request(NDRPacket):
 class get_IDataCollectorSet_Security_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrSecurity", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrSecurity", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1580,7 +1656,9 @@ class get_IDataCollectorSet_Security_Response(NDRPacket):
 
 class put_IDataCollectorSet_Security_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrSecurity", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrSecurity", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1627,7 +1705,9 @@ class SetCredentials_Response(NDRPacket):
 
 class Query_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRFullPointerField(
             NDRPacketField("server", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
         ),
@@ -1640,7 +1720,9 @@ class Query_Response(NDRPacket):
 
 class Commit_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRFullPointerField(
             NDRPacketField("server", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
         ),
@@ -1681,7 +1763,11 @@ class Stop_Response(NDRPacket):
 
 
 class SetXml_Request(NDRPacket):
-    fields_desc = [NDRPacketField("xml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("xml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class SetXml_Response(NDRPacket):
@@ -1708,7 +1794,9 @@ class GetValue_Request(NDRPacket):
 class GetValue_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2048,7 +2136,9 @@ class get_IDataManager_ReportSchema_Request(NDRPacket):
 class get_IDataManager_ReportSchema_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("ReportSchema", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("ReportSchema", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2056,7 +2146,9 @@ class get_IDataManager_ReportSchema_Response(NDRPacket):
 
 class put_IDataManager_ReportSchema_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("ReportSchema", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("ReportSchema", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -2071,7 +2163,9 @@ class get_IDataManager_ReportFileName_Request(NDRPacket):
 class get_IDataManager_ReportFileName_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrFilename", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrFilename", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2079,7 +2173,9 @@ class get_IDataManager_ReportFileName_Response(NDRPacket):
 
 class put_IDataManager_ReportFileName_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("pbstrFilename", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("pbstrFilename", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -2094,14 +2190,20 @@ class get_IDataManager_RuleTargetFileName_Request(NDRPacket):
 class get_IDataManager_RuleTargetFileName_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("Filename", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("Filename", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IDataManager_RuleTargetFileName_Request(NDRPacket):
-    fields_desc = [NDRPacketField("Filename", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("Filename", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IDataManager_RuleTargetFileName_Response(NDRPacket):
@@ -2115,7 +2217,9 @@ class get_IDataManager_EventsFileName_Request(NDRPacket):
 class get_IDataManager_EventsFileName_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrFilename", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrFilename", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2123,7 +2227,9 @@ class get_IDataManager_EventsFileName_Response(NDRPacket):
 
 class put_IDataManager_EventsFileName_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("pbstrFilename", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("pbstrFilename", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -2138,14 +2244,20 @@ class get_IDataManager_Rules_Request(NDRPacket):
 class get_IDataManager_Rules_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IDataManager_Rules_Request(NDRPacket):
-    fields_desc = [NDRPacketField("bstrXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("bstrXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IDataManager_Rules_Response(NDRPacket):
@@ -2163,7 +2275,9 @@ class DataManagerSteps(IntEnum):
 class Run_Request(NDRPacket):
     fields_desc = [
         NDRInt3264EnumField("Steps", 0, DataManagerSteps),
-        NDRPacketField("bstrFolder", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrFolder", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -2178,8 +2292,12 @@ class Run_Response(NDRPacket):
 
 class Extract_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("CabFilename", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("DestinationPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("CabFilename", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("DestinationPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -2339,7 +2457,11 @@ class get_IFolderAction_SendCabTo_Request(NDRPacket):
 class get_IFolderAction_SendCabTo_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrDestination", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrDestination", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2347,7 +2469,9 @@ class get_IFolderAction_SendCabTo_Response(NDRPacket):
 
 class put_IFolderAction_SendCabTo_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrDestination", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrDestination", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -2391,7 +2515,9 @@ class get_IFolderActionCollection_Count_Response(NDRPacket):
 
 
 class get_IFolderActionCollection_Item_Request(NDRPacket):
-    fields_desc = [NDRPacketField("Index", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("Index", wireVARIANTStr(), wireVARIANTStr))
+    ]
 
 
 class get_IFolderActionCollection_Item_Response(NDRPacket):
@@ -2532,14 +2658,20 @@ class get_IDataCollector_FileName_Request(NDRPacket):
 class get_IDataCollector_FileName_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IDataCollector_FileName_Request(NDRPacket):
-    fields_desc = [NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IDataCollector_FileName_Response(NDRPacket):
@@ -2572,14 +2704,20 @@ class get_IDataCollector_FileNameFormatPattern_Request(NDRPacket):
 class get_IDataCollector_FileNameFormatPattern_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pattern", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pattern", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IDataCollector_FileNameFormatPattern_Request(NDRPacket):
-    fields_desc = [NDRPacketField("pattern", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("pattern", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IDataCollector_FileNameFormatPattern_Response(NDRPacket):
@@ -2593,14 +2731,20 @@ class get_IDataCollector_LatestOutputLocation_Request(NDRPacket):
 class get_IDataCollector_LatestOutputLocation_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IDataCollector_LatestOutputLocation_Request(NDRPacket):
-    fields_desc = [NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IDataCollector_LatestOutputLocation_Response(NDRPacket):
@@ -2662,14 +2806,20 @@ class get_IDataCollector_Name_Request(NDRPacket):
 class get_IDataCollector_Name_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IDataCollector_Name_Request(NDRPacket):
-    fields_desc = [NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IDataCollector_Name_Response(NDRPacket):
@@ -2683,7 +2833,9 @@ class get_IDataCollector_OutputLocation_Request(NDRPacket):
 class get_IDataCollector_OutputLocation_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("path", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2704,14 +2856,20 @@ class get_IDataCollector_Xml_Request(NDRPacket):
 class get_IDataCollector_Xml_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("Xml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("Xml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class SetXml_Request(NDRPacket):
-    fields_desc = [NDRPacketField("Xml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("Xml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class SetXml_Response(NDRPacket):
@@ -2815,14 +2973,20 @@ class get_IPerformanceCounterDataCollector_DataSourceName_Request(NDRPacket):
 class get_IPerformanceCounterDataCollector_DataSourceName_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("dsn", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("dsn", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IPerformanceCounterDataCollector_DataSourceName_Request(NDRPacket):
-    fields_desc = [NDRPacketField("dsn", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("dsn", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IPerformanceCounterDataCollector_DataSourceName_Response(NDRPacket):
@@ -2835,13 +2999,17 @@ class get_IPerformanceCounterDataCollector_PerformanceCounters_Request(NDRPacket
 
 class get_IPerformanceCounterDataCollector_PerformanceCounters_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("counters", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("counters", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IPerformanceCounterDataCollector_PerformanceCounters_Request(NDRPacket):
-    fields_desc = [NDRPacketField("counters", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("counters", SAFEARRAY(), SAFEARRAY))
+    ]
 
 
 class put_IPerformanceCounterDataCollector_PerformanceCounters_Response(NDRPacket):
@@ -3261,14 +3429,20 @@ class get_ITraceDataCollector_SessionName_Request(NDRPacket):
 class get_ITraceDataCollector_SessionName_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_ITraceDataCollector_SessionName_Request(NDRPacket):
-    fields_desc = [NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_ITraceDataCollector_SessionName_Response(NDRPacket):
@@ -3595,13 +3769,15 @@ class get_IConfigurationDataCollector_Files_Request(NDRPacket):
 
 class get_IConfigurationDataCollector_Files_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("Files", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("Files", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IConfigurationDataCollector_Files_Request(NDRPacket):
-    fields_desc = [NDRPacketField("Files", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [NDRFullPointerField(NDRPacketField("Files", SAFEARRAY(), SAFEARRAY))]
 
 
 class put_IConfigurationDataCollector_Files_Response(NDRPacket):
@@ -3614,13 +3790,17 @@ class get_IConfigurationDataCollector_ManagementQueries_Request(NDRPacket):
 
 class get_IConfigurationDataCollector_ManagementQueries_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("Queries", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("Queries", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IConfigurationDataCollector_ManagementQueries_Request(NDRPacket):
-    fields_desc = [NDRPacketField("Queries", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("Queries", SAFEARRAY(), SAFEARRAY))
+    ]
 
 
 class put_IConfigurationDataCollector_ManagementQueries_Response(NDRPacket):
@@ -3649,13 +3829,15 @@ class get_IConfigurationDataCollector_RegistryKeys_Request(NDRPacket):
 
 class get_IConfigurationDataCollector_RegistryKeys_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("query", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("query", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IConfigurationDataCollector_RegistryKeys_Request(NDRPacket):
-    fields_desc = [NDRPacketField("query", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [NDRFullPointerField(NDRPacketField("query", SAFEARRAY(), SAFEARRAY))]
 
 
 class put_IConfigurationDataCollector_RegistryKeys_Response(NDRPacket):
@@ -3685,14 +3867,20 @@ class get_IConfigurationDataCollector_SystemStateFile_Request(NDRPacket):
 class get_IConfigurationDataCollector_SystemStateFile_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("FileName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("FileName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IConfigurationDataCollector_SystemStateFile_Request(NDRPacket):
-    fields_desc = [NDRPacketField("FileName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("FileName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IConfigurationDataCollector_SystemStateFile_Response(NDRPacket):
@@ -3862,13 +4050,17 @@ class get_IAlertDataCollector_AlertThresholds_Request(NDRPacket):
 
 class get_IAlertDataCollector_AlertThresholds_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("alerts", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("alerts", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IAlertDataCollector_AlertThresholds_Request(NDRPacket):
-    fields_desc = [NDRPacketField("alerts", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("alerts", SAFEARRAY(), SAFEARRAY))
+    ]
 
 
 class put_IAlertDataCollector_AlertThresholds_Response(NDRPacket):
@@ -3914,14 +4106,20 @@ class get_IAlertDataCollector_Task_Request(NDRPacket):
 class get_IAlertDataCollector_Task_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("task", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("task", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IAlertDataCollector_Task_Request(NDRPacket):
-    fields_desc = [NDRPacketField("task", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("task", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IAlertDataCollector_Task_Response(NDRPacket):
@@ -3951,14 +4149,20 @@ class get_IAlertDataCollector_TaskArguments_Request(NDRPacket):
 class get_IAlertDataCollector_TaskArguments_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("task", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("task", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IAlertDataCollector_TaskArguments_Request(NDRPacket):
-    fields_desc = [NDRPacketField("task", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("task", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IAlertDataCollector_TaskArguments_Response(NDRPacket):
@@ -3972,14 +4176,20 @@ class get_IAlertDataCollector_TaskUserTextArguments_Request(NDRPacket):
 class get_IAlertDataCollector_TaskUserTextArguments_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("task", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("task", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IAlertDataCollector_TaskUserTextArguments_Request(NDRPacket):
-    fields_desc = [NDRPacketField("task", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("task", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IAlertDataCollector_TaskUserTextArguments_Response(NDRPacket):
@@ -3993,14 +4203,20 @@ class get_IAlertDataCollector_TriggerDataCollectorSet_Request(NDRPacket):
 class get_IAlertDataCollector_TriggerDataCollectorSet_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IAlertDataCollector_TriggerDataCollectorSet_Request(NDRPacket):
-    fields_desc = [NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IAlertDataCollector_TriggerDataCollectorSet_Response(NDRPacket):
@@ -4193,14 +4409,20 @@ class get_IApiTracingDataCollector_ExePath_Request(NDRPacket):
 class get_IApiTracingDataCollector_ExePath_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("exepath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("exepath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IApiTracingDataCollector_ExePath_Request(NDRPacket):
-    fields_desc = [NDRPacketField("exepath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("exepath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IApiTracingDataCollector_ExePath_Response(NDRPacket):
@@ -4214,7 +4436,9 @@ class get_IApiTracingDataCollector_LogFilePath_Request(NDRPacket):
 class get_IApiTracingDataCollector_LogFilePath_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("logfilepath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("logfilepath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -4222,7 +4446,9 @@ class get_IApiTracingDataCollector_LogFilePath_Response(NDRPacket):
 
 class put_IApiTracingDataCollector_LogFilePath_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("logfilepath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("logfilepath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -4236,13 +4462,19 @@ class get_IApiTracingDataCollector_IncludeModules_Request(NDRPacket):
 
 class get_IApiTracingDataCollector_IncludeModules_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("includemodules", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("includemodules", SAFEARRAY(), SAFEARRAY)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IApiTracingDataCollector_IncludeModules_Request(NDRPacket):
-    fields_desc = [NDRPacketField("includemodules", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("includemodules", SAFEARRAY(), SAFEARRAY))
+    ]
 
 
 class put_IApiTracingDataCollector_IncludeModules_Response(NDRPacket):
@@ -4255,13 +4487,17 @@ class get_IApiTracingDataCollector_IncludeApis_Request(NDRPacket):
 
 class get_IApiTracingDataCollector_IncludeApis_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("includeapis", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("includeapis", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IApiTracingDataCollector_IncludeApis_Request(NDRPacket):
-    fields_desc = [NDRPacketField("includeapis", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("includeapis", SAFEARRAY(), SAFEARRAY))
+    ]
 
 
 class put_IApiTracingDataCollector_IncludeApis_Response(NDRPacket):
@@ -4274,13 +4510,17 @@ class get_IApiTracingDataCollector_ExcludeApis_Request(NDRPacket):
 
 class get_IApiTracingDataCollector_ExcludeApis_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("excludeapis", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("excludeapis", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IApiTracingDataCollector_ExcludeApis_Request(NDRPacket):
-    fields_desc = [NDRPacketField("excludeapis", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("excludeapis", SAFEARRAY(), SAFEARRAY))
+    ]
 
 
 class put_IApiTracingDataCollector_ExcludeApis_Response(NDRPacket):
@@ -4437,7 +4677,9 @@ class get_IDataCollectorCollection_Count_Response(NDRPacket):
 
 
 class get_IDataCollectorCollection_Item_Request(NDRPacket):
-    fields_desc = [NDRPacketField("index", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("index", wireVARIANTStr(), wireVARIANTStr))
+    ]
 
 
 class get_IDataCollectorCollection_Item_Response(NDRPacket):
@@ -4495,7 +4737,11 @@ class AddRange_Response(NDRPacket):
 
 
 class CreateDataCollectorFromXml_Request(NDRPacket):
-    fields_desc = [NDRPacketField("bstrXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("bstrXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class CreateDataCollectorFromXml_Response(NDRPacket):
@@ -4567,7 +4813,9 @@ class get_IDataCollectorSetCollection_Count_Response(NDRPacket):
 
 
 class get_IDataCollectorSetCollection_Item_Request(NDRPacket):
-    fields_desc = [NDRPacketField("index", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("index", wireVARIANTStr(), wireVARIANTStr))
+    ]
 
 
 class get_IDataCollectorSetCollection_Item_Response(NDRPacket):
@@ -4678,14 +4926,20 @@ class get_ITraceDataProvider_DisplayName_Request(NDRPacket):
 class get_ITraceDataProvider_DisplayName_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_ITraceDataProvider_DisplayName_Request(NDRPacket):
-    fields_desc = [NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("name", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_ITraceDataProvider_DisplayName_Response(NDRPacket):
@@ -4798,13 +5052,15 @@ class get_ITraceDataProvider_FilterData_Request(NDRPacket):
 
 class get_ITraceDataProvider_FilterData_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("ppData", SAFEARRAY(), SAFEARRAY)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("ppData", SAFEARRAY(), SAFEARRAY))
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_ITraceDataProvider_FilterData_Request(NDRPacket):
-    fields_desc = [NDRPacketField("pData", SAFEARRAY(), SAFEARRAY)]
+    fields_desc = [NDRFullPointerField(NDRPacketField("pData", SAFEARRAY(), SAFEARRAY))]
 
 
 class put_ITraceDataProvider_FilterData_Response(NDRPacket):
@@ -4813,7 +5069,9 @@ class put_ITraceDataProvider_FilterData_Response(NDRPacket):
 
 class Query_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRFullPointerField(
             NDRPacketField("bstrServer", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
         ),
@@ -4833,7 +5091,11 @@ class Resolve_Response(NDRPacket):
 
 
 class SetSecurity_Request(NDRPacket):
-    fields_desc = [NDRPacketField("Sddl", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("Sddl", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class SetSecurity_Response(NDRPacket):
@@ -4847,7 +5109,9 @@ class GetSecurity_Request(NDRPacket):
 class GetSecurity_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("Sddl", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("Sddl", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -4948,7 +5212,9 @@ class get_ITraceDataProviderCollection_Count_Response(NDRPacket):
 
 
 class get_ITraceDataProviderCollection_Item_Request(NDRPacket):
-    fields_desc = [NDRPacketField("index", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("index", wireVARIANTStr(), wireVARIANTStr))
+    ]
 
 
 class get_ITraceDataProviderCollection_Item_Response(NDRPacket):
@@ -5085,13 +5351,19 @@ class get_ISchedule_StartDate_Request(NDRPacket):
 
 class get_ISchedule_StartDate_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("start", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("start", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_ISchedule_StartDate_Request(NDRPacket):
-    fields_desc = [NDRPacketField("start", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("start", wireVARIANTStr(), wireVARIANTStr))
+    ]
 
 
 class put_ISchedule_StartDate_Response(NDRPacket):
@@ -5104,13 +5376,17 @@ class get_ISchedule_EndDate_Request(NDRPacket):
 
 class get_ISchedule_EndDate_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("end", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(NDRPacketField("end", wireVARIANTStr(), wireVARIANTStr))
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_ISchedule_EndDate_Request(NDRPacket):
-    fields_desc = [NDRPacketField("end", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("end", wireVARIANTStr(), wireVARIANTStr))
+    ]
 
 
 class put_ISchedule_EndDate_Response(NDRPacket):
@@ -5123,13 +5399,19 @@ class get_ISchedule_StartTime_Request(NDRPacket):
 
 class get_ISchedule_StartTime_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("start", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("start", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_ISchedule_StartTime_Request(NDRPacket):
-    fields_desc = [NDRPacketField("start", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("start", wireVARIANTStr(), wireVARIANTStr))
+    ]
 
 
 class put_ISchedule_StartTime_Response(NDRPacket):
@@ -5196,7 +5478,9 @@ class get_IScheduleCollection_Count_Response(NDRPacket):
 
 
 class get_IScheduleCollection_Item_Request(NDRPacket):
-    fields_desc = [NDRPacketField("index", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("index", wireVARIANTStr(), wireVARIANTStr))
+    ]
 
 
 class get_IScheduleCollection_Item_Response(NDRPacket):
@@ -5303,7 +5587,9 @@ class get_IValueMapItem_Description_Request(NDRPacket):
 class get_IValueMapItem_Description_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("description", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("description", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -5311,7 +5597,9 @@ class get_IValueMapItem_Description_Response(NDRPacket):
 
 class put_IValueMapItem_Description_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("description", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("description", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -5342,14 +5630,20 @@ class get_IValueMapItem_Key_Request(NDRPacket):
 class get_IValueMapItem_Key_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("key", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("key", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IValueMapItem_Key_Request(NDRPacket):
-    fields_desc = [NDRPacketField("key", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("key", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IValueMapItem_Key_Response(NDRPacket):
@@ -5362,13 +5656,19 @@ class get_IValueMapItem_Value_Request(NDRPacket):
 
 class get_IValueMapItem_Value_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("Value", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("Value", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IValueMapItem_Value_Request(NDRPacket):
-    fields_desc = [NDRPacketField("Value", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("Value", wireVARIANTStr(), wireVARIANTStr))
+    ]
 
 
 class put_IValueMapItem_Value_Response(NDRPacket):
@@ -5443,7 +5743,9 @@ class get_IValueMap_Count_Response(NDRPacket):
 
 
 class get_IValueMap_Item_Request(NDRPacket):
-    fields_desc = [NDRPacketField("index", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("index", wireVARIANTStr(), wireVARIANTStr))
+    ]
 
 
 class get_IValueMap_Item_Response(NDRPacket):
@@ -5475,7 +5777,9 @@ class get_IValueMap_Description_Request(NDRPacket):
 class get_IValueMap_Description_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("description", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("description", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -5483,7 +5787,9 @@ class get_IValueMap_Description_Response(NDRPacket):
 
 class put_IValueMap_Description_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("description", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("description", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -5497,13 +5803,19 @@ class get_IValueMap_Value_Request(NDRPacket):
 
 class get_IValueMap_Value_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("Value", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("Value", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IValueMap_Value_Request(NDRPacket):
-    fields_desc = [NDRPacketField("Value", wireVARIANTStr(), wireVARIANTStr)]
+    fields_desc = [
+        NDRFullPointerField(NDRPacketField("Value", wireVARIANTStr(), wireVARIANTStr))
+    ]
 
 
 class put_IValueMap_Value_Response(NDRPacket):

--- a/scapy-rpc/msrpcs/ms_rai.py
+++ b/scapy-rpc/msrpcs/ms_rai.py
@@ -1016,12 +1016,14 @@ class Invoke_Request(NDRPacket):
         NDRConfFieldListField(
             "rgVarRefIdx", [], NDRIntField("", 0), size_is=lambda pkt: pkt.cVarRef
         ),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
     ]
 
@@ -1029,16 +1031,20 @@ class Invoke_Request(NDRPacket):
 class Invoke_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRPacketField("pExcepInfo", EXCEPINFO(), EXCEPINFO),
         NDRIntField("pArgErr", 0),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1079,7 +1085,9 @@ class get_IPCHCollection_Item_Request(NDRPacket):
 class get_IPCHCollection_Item_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("ppEntry", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("ppEntry", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1169,14 +1177,20 @@ class get_ISAFSession_DomainName_Request(NDRPacket):
 class get_ISAFSession_DomainName_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pVal", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pVal", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_ISAFSession_DomainName_Request(NDRPacket):
-    fields_desc = [NDRPacketField("pVal", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("pVal", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_ISAFSession_DomainName_Response(NDRPacket):
@@ -1190,14 +1204,20 @@ class get_ISAFSession_UserName_Request(NDRPacket):
 class get_ISAFSession_UserName_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pVal", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pVal", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_ISAFSession_UserName_Request(NDRPacket):
-    fields_desc = [NDRPacketField("pVal", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("pVal", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_ISAFSession_UserName_Response(NDRPacket):

--- a/scapy-rpc/msrpcs/ms_raiw_winsif.py
+++ b/scapy-rpc/msrpcs/ms_raiw_winsif.py
@@ -31,6 +31,7 @@ from scapy.layers.dcerpc import (
     NDRIntField,
     NDRLongField,
     NDRPacketField,
+    NDRRefEmbPointerField,
     NDRShortField,
     NDRSignedLongField,
     NDRSignedShortField,
@@ -292,7 +293,7 @@ class PWINSINTF_RECS_T(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
         NDRIntField("BuffSize", 0),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "pRow", [], PWINSINTF_RECORD_ACTION_T, size_is=lambda pkt: pkt.NoOfRecs
             )

--- a/scapy-rpc/msrpcs/ms_rpcl.py
+++ b/scapy-rpc/msrpcs/ms_rpcl.py
@@ -56,7 +56,7 @@ class RPC_SYNTAX_IDENTIFIER(NDRPacket):
 class I_nsi_lookup_begin_Request(NDRPacket):
     fields_desc = [
         NDRIntField("entry_name_syntax", 0),
-        NDRConfVarStrNullFieldUtf16("entry_name", ""),
+        NDRFullPointerField(NDRConfVarStrNullFieldUtf16("entry_name", "")),
         NDRFullPointerField(
             NDRPacketField(
                 "interfaceid", RPC_SYNTAX_IDENTIFIER(), RPC_SYNTAX_IDENTIFIER
@@ -65,7 +65,7 @@ class I_nsi_lookup_begin_Request(NDRPacket):
         NDRFullPointerField(
             NDRPacketField("xfersyntax", RPC_SYNTAX_IDENTIFIER(), RPC_SYNTAX_IDENTIFIER)
         ),
-        NDRPacketField("obj_uuid", GUID(), GUID),
+        NDRFullPointerField(NDRPacketField("obj_uuid", GUID(), GUID)),
         NDRIntField("binding_max_count", 0),
         NDRIntField("MaxCacheAge", 0),
     ]
@@ -126,8 +126,10 @@ class I_nsi_lookup_next_Request(NDRPacket):
 class I_nsi_lookup_next_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "binding_vector", NSI_BINDING_VECTOR_T(), NSI_BINDING_VECTOR_T
+            NDRFullPointerField(
+                NDRPacketField(
+                    "binding_vector", NSI_BINDING_VECTOR_T(), NSI_BINDING_VECTOR_T
+                )
             )
         ),
         NDRShortField("status", 0),
@@ -158,7 +160,9 @@ class I_nsi_entry_object_inq_next_Request(NDRPacket):
 class I_nsi_entry_object_inq_next_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("uuid_vec", NSI_UUID_VECTOR_T(), NSI_UUID_VECTOR_T)
+            NDRFullPointerField(
+                NDRPacketField("uuid_vec", NSI_UUID_VECTOR_T(), NSI_UUID_VECTOR_T)
+            )
         ),
         NDRShortField("status", 0),
         NDRIntField("comm_status", 0),
@@ -188,7 +192,7 @@ class I_nsi_entry_object_inq_done_Response(NDRPacket):
 class I_nsi_entry_object_inq_begin_Request(NDRPacket):
     fields_desc = [
         NDRIntField("EntryNameSyntax", 0),
-        NDRConfVarStrNullFieldUtf16("EntryName", ""),
+        NDRFullPointerField(NDRConfVarStrNullFieldUtf16("EntryName", "")),
     ]
 
 

--- a/scapy-rpc/msrpcs/ms_rrasm.py
+++ b/scapy-rpc/msrpcs/ms_rrasm.py
@@ -2213,7 +2213,9 @@ class GetStringFromId_Request(NDRPacket):
 class GetStringFromId_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pBstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pBstrName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]

--- a/scapy-rpc/msrpcs/ms_rrp.py
+++ b/scapy-rpc/msrpcs/ms_rrp.py
@@ -27,6 +27,7 @@ from scapy.layers.dcerpc import (
     NDRFullPointerField,
     NDRIntField,
     NDRPacketField,
+    NDRRefEmbPointerField,
     NDRShortField,
     register_dcerpc_interface,
 )
@@ -165,12 +166,8 @@ class BaseRegCreateKey_Request(NDRPacket):
         NDRPacketField("lpClass", RPC_UNICODE_STRING(), RPC_UNICODE_STRING),
         NDRIntField("dwOptions", 0),
         NDRIntField("samDesired", 0),
-        NDRFullPointerField(
-            NDRPacketField(
-                "lpSecurityAttributes",
-                PRPC_SECURITY_ATTRIBUTES(),
-                PRPC_SECURITY_ATTRIBUTES,
-            )
+        NDRPacketField(
+            "lpSecurityAttributes", PRPC_SECURITY_ATTRIBUTES(), PRPC_SECURITY_ATTRIBUTES
         ),
         NDRFullPointerField(NDRIntField("lpdwDisposition", 0)),
     ]
@@ -237,9 +234,7 @@ class BaseRegEnumKey_Request(NDRPacket):
         NDRFullPointerField(
             NDRPacketField("lpClassIn", RPC_UNICODE_STRING(), RPC_UNICODE_STRING)
         ),
-        NDRFullPointerField(
-            NDRPacketField("lpftLastWriteTime", PFILETIME(), PFILETIME)
-        ),
+        NDRPacketField("lpftLastWriteTime", PFILETIME(), PFILETIME),
     ]
 
 
@@ -249,9 +244,7 @@ class BaseRegEnumKey_Response(NDRPacket):
         NDRFullPointerField(
             NDRPacketField("lplpClassOut", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING)
         ),
-        NDRFullPointerField(
-            NDRPacketField("lpftLastWriteTime", PFILETIME(), PFILETIME)
-        ),
+        NDRPacketField("lpftLastWriteTime", PFILETIME(), PFILETIME),
         NDRIntField("status", 0),
     ]
 
@@ -454,12 +447,8 @@ class BaseRegSaveKey_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("hKey", NDRContextHandle(), NDRContextHandle),
         NDRPacketField("lpFile", RPC_UNICODE_STRING(), RPC_UNICODE_STRING),
-        NDRFullPointerField(
-            NDRPacketField(
-                "pSecurityAttributes",
-                PRPC_SECURITY_ATTRIBUTES(),
-                PRPC_SECURITY_ATTRIBUTES,
-            )
+        NDRPacketField(
+            "pSecurityAttributes", PRPC_SECURITY_ATTRIBUTES(), PRPC_SECURITY_ATTRIBUTES
         ),
     ]
 
@@ -534,7 +523,7 @@ class OpenCurrentConfig_Response(NDRPacket):
 class PRVALENT(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRPacketField("ve_valuename", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING)
         ),
         NDRIntField("ve_valuelen", 0),
@@ -592,12 +581,8 @@ class BaseRegSaveKeyEx_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("hKey", NDRContextHandle(), NDRContextHandle),
         NDRPacketField("lpFile", RPC_UNICODE_STRING(), RPC_UNICODE_STRING),
-        NDRFullPointerField(
-            NDRPacketField(
-                "pSecurityAttributes",
-                PRPC_SECURITY_ATTRIBUTES(),
-                PRPC_SECURITY_ATTRIBUTES,
-            )
+        NDRPacketField(
+            "pSecurityAttributes", PRPC_SECURITY_ATTRIBUTES(), PRPC_SECURITY_ATTRIBUTES
         ),
         NDRIntField("Flags", 0),
     ]

--- a/scapy-rpc/msrpcs/ms_rsmp.py
+++ b/scapy-rpc/msrpcs/ms_rsmp.py
@@ -514,12 +514,10 @@ class CreateNtmsMediaPoolA_Request(NDRPacket):
         NDRConfVarStrNullField("lpPoolName", ""),
         NDRFullPointerField(NDRPacketField("lpMediaType", GUID(), GUID)),
         NDRIntField("dwOptions", 0),
-        NDRFullPointerField(
-            NDRPacketField(
-                "lpSecurityAttributes",
-                LPSECURITY_ATTRIBUTES_NTMS(),
-                LPSECURITY_ATTRIBUTES_NTMS,
-            )
+        NDRPacketField(
+            "lpSecurityAttributes",
+            LPSECURITY_ATTRIBUTES_NTMS(),
+            LPSECURITY_ATTRIBUTES_NTMS,
         ),
     ]
 
@@ -533,12 +531,10 @@ class CreateNtmsMediaPoolW_Request(NDRPacket):
         NDRConfVarStrNullFieldUtf16("lpPoolName", ""),
         NDRFullPointerField(NDRPacketField("lpMediaType", GUID(), GUID)),
         NDRIntField("dwOptions", 0),
-        NDRFullPointerField(
-            NDRPacketField(
-                "lpSecurityAttributes",
-                LPSECURITY_ATTRIBUTES_NTMS(),
-                LPSECURITY_ATTRIBUTES_NTMS,
-            )
+        NDRPacketField(
+            "lpSecurityAttributes",
+            LPSECURITY_ATTRIBUTES_NTMS(),
+            LPSECURITY_ATTRIBUTES_NTMS,
         ),
     ]
 
@@ -2258,11 +2254,7 @@ class LPRSM_MESSAGE(NDRPacket):
 
 
 class SendMessage_Request(NDRPacket):
-    fields_desc = [
-        NDRFullPointerField(
-            NDRPacketField("lpRsmMessage", LPRSM_MESSAGE(), LPRSM_MESSAGE)
-        )
-    ]
+    fields_desc = [NDRPacketField("lpRsmMessage", LPRSM_MESSAGE(), LPRSM_MESSAGE)]
 
 
 class SendMessage_Response(NDRPacket):

--- a/scapy-rpc/msrpcs/ms_rsp_initshutdown.py
+++ b/scapy-rpc/msrpcs/ms_rsp_initshutdown.py
@@ -50,9 +50,7 @@ class PREG_UNICODE_STRING(NDRPacket):
 class BaseInitiateShutdown_Request(NDRPacket):
     fields_desc = [
         NDRFullPointerField(NDRShortField("ServerName", 0)),
-        NDRFullPointerField(
-            NDRPacketField("lpMessage", PREG_UNICODE_STRING(), PREG_UNICODE_STRING)
-        ),
+        NDRPacketField("lpMessage", PREG_UNICODE_STRING(), PREG_UNICODE_STRING),
         NDRIntField("dwTimeout", 0),
         NDRByteField("bForceAppsClosed", 0),
         NDRByteField("bRebootAfterShutdown", 0),
@@ -74,9 +72,7 @@ class BaseAbortShutdown_Response(NDRPacket):
 class BaseInitiateShutdownEx_Request(NDRPacket):
     fields_desc = [
         NDRFullPointerField(NDRShortField("ServerName", 0)),
-        NDRFullPointerField(
-            NDRPacketField("lpMessage", PREG_UNICODE_STRING(), PREG_UNICODE_STRING)
-        ),
+        NDRPacketField("lpMessage", PREG_UNICODE_STRING(), PREG_UNICODE_STRING),
         NDRIntField("dwTimeout", 0),
         NDRByteField("bForceAppsClosed", 0),
         NDRByteField("bRebootAfterShutdown", 0),

--- a/scapy-rpc/msrpcs/ms_rsp_windowsshutdown.py
+++ b/scapy-rpc/msrpcs/ms_rsp_windowsshutdown.py
@@ -20,7 +20,6 @@ from scapy.layers.dcerpc import (
     NDRConfVarStrLenField,
     NDRConfVarStrLenFieldUtf16,
     NDRFullEmbPointerField,
-    NDRFullPointerField,
     NDRIntField,
     NDRPacketField,
     NDRShortField,
@@ -48,15 +47,11 @@ class PREG_UNICODE_STRING(NDRPacket):
 
 class WsdrInitiateShutdown_Request(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(
-            NDRPacketField("lpMessage", PREG_UNICODE_STRING(), PREG_UNICODE_STRING)
-        ),
+        NDRPacketField("lpMessage", PREG_UNICODE_STRING(), PREG_UNICODE_STRING),
         NDRIntField("dwGracePeriod", 0),
         NDRIntField("dwShudownFlags", 0),
         NDRIntField("dwReason", 0),
-        NDRFullPointerField(
-            NDRPacketField("lpClientHint", PREG_UNICODE_STRING(), PREG_UNICODE_STRING)
-        ),
+        NDRPacketField("lpClientHint", PREG_UNICODE_STRING(), PREG_UNICODE_STRING),
     ]
 
 
@@ -66,9 +61,7 @@ class WsdrInitiateShutdown_Response(NDRPacket):
 
 class WsdrAbortShutdown_Request(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(
-            NDRPacketField("lpClientHint", PREG_UNICODE_STRING(), PREG_UNICODE_STRING)
-        )
+        NDRPacketField("lpClientHint", PREG_UNICODE_STRING(), PREG_UNICODE_STRING)
     ]
 
 

--- a/scapy-rpc/msrpcs/ms_rsp_winreg.py
+++ b/scapy-rpc/msrpcs/ms_rsp_winreg.py
@@ -50,9 +50,7 @@ class PREG_UNICODE_STRING(NDRPacket):
 class BaseInitiateSystemShutdown_Request(NDRPacket):
     fields_desc = [
         NDRFullPointerField(NDRShortField("ServerName", 0)),
-        NDRFullPointerField(
-            NDRPacketField("lpMessage", PREG_UNICODE_STRING(), PREG_UNICODE_STRING)
-        ),
+        NDRPacketField("lpMessage", PREG_UNICODE_STRING(), PREG_UNICODE_STRING),
         NDRIntField("dwTimeout", 0),
         NDRByteField("bForceAppsClosed", 0),
         NDRByteField("bRebootAfterShutdown", 0),
@@ -74,9 +72,7 @@ class BaseAbortSystemShutdown_Response(NDRPacket):
 class BaseInitiateSystemShutdownEx_Request(NDRPacket):
     fields_desc = [
         NDRFullPointerField(NDRShortField("ServerName", 0)),
-        NDRFullPointerField(
-            NDRPacketField("lpMessage", PREG_UNICODE_STRING(), PREG_UNICODE_STRING)
-        ),
+        NDRPacketField("lpMessage", PREG_UNICODE_STRING(), PREG_UNICODE_STRING),
         NDRIntField("dwTimeout", 0),
         NDRByteField("bForceAppsClosed", 0),
         NDRByteField("bRebootAfterShutdown", 0),

--- a/scapy-rpc/msrpcs/ms_samr.py
+++ b/scapy-rpc/msrpcs/ms_samr.py
@@ -35,6 +35,7 @@ from scapy.layers.dcerpc import (
     NDRIntField,
     NDRLongField,
     NDRPacketField,
+    NDRRefEmbPointerField,
     NDRShortField,
     NDRSignedIntField,
     NDRSignedLongField,
@@ -958,7 +959,7 @@ class SamrEnumerateAliasesInDomain_Response(NDRPacket):
 class PSAMPR_SID_INFORMATION(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
-        NDRFullEmbPointerField(NDRPacketField("SidPointer", PRPC_SID(), PRPC_SID))
+        NDRRefEmbPointerField(NDRPacketField("SidPointer", PRPC_SID(), PRPC_SID))
     ]
 
 
@@ -1026,7 +1027,7 @@ class PSAMPR_RETURNED_USTRING_ARRAY(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
         NDRIntField("Count", None, size_of="Element"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "Element", [], PRPC_UNICODE_STRING, size_is=lambda pkt: pkt.Count
             )
@@ -2947,50 +2948,38 @@ class SamrChangePasswordUser_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("UserHandle", NDRContextHandle(), NDRContextHandle),
         NDRByteField("LmPresent", 0),
-        NDRFullPointerField(
-            NDRPacketField(
-                "OldLmEncryptedWithNewLm",
-                PENCRYPTED_LM_OWF_PASSWORD(),
-                PENCRYPTED_LM_OWF_PASSWORD,
-            )
+        NDRPacketField(
+            "OldLmEncryptedWithNewLm",
+            PENCRYPTED_LM_OWF_PASSWORD(),
+            PENCRYPTED_LM_OWF_PASSWORD,
         ),
-        NDRFullPointerField(
-            NDRPacketField(
-                "NewLmEncryptedWithOldLm",
-                PENCRYPTED_LM_OWF_PASSWORD(),
-                PENCRYPTED_LM_OWF_PASSWORD,
-            )
+        NDRPacketField(
+            "NewLmEncryptedWithOldLm",
+            PENCRYPTED_LM_OWF_PASSWORD(),
+            PENCRYPTED_LM_OWF_PASSWORD,
         ),
         NDRByteField("NtPresent", 0),
-        NDRFullPointerField(
-            NDRPacketField(
-                "OldNtEncryptedWithNewNt",
-                PENCRYPTED_NT_OWF_PASSWORD(),
-                PENCRYPTED_NT_OWF_PASSWORD,
-            )
+        NDRPacketField(
+            "OldNtEncryptedWithNewNt",
+            PENCRYPTED_NT_OWF_PASSWORD(),
+            PENCRYPTED_NT_OWF_PASSWORD,
         ),
-        NDRFullPointerField(
-            NDRPacketField(
-                "NewNtEncryptedWithOldNt",
-                PENCRYPTED_NT_OWF_PASSWORD(),
-                PENCRYPTED_NT_OWF_PASSWORD,
-            )
+        NDRPacketField(
+            "NewNtEncryptedWithOldNt",
+            PENCRYPTED_NT_OWF_PASSWORD(),
+            PENCRYPTED_NT_OWF_PASSWORD,
         ),
         NDRByteField("NtCrossEncryptionPresent", 0),
-        NDRFullPointerField(
-            NDRPacketField(
-                "NewNtEncryptedWithNewLm",
-                PENCRYPTED_NT_OWF_PASSWORD(),
-                PENCRYPTED_NT_OWF_PASSWORD,
-            )
+        NDRPacketField(
+            "NewNtEncryptedWithNewLm",
+            PENCRYPTED_NT_OWF_PASSWORD(),
+            PENCRYPTED_NT_OWF_PASSWORD,
         ),
         NDRByteField("LmCrossEncryptionPresent", 0),
-        NDRFullPointerField(
-            NDRPacketField(
-                "NewLmEncryptedWithNewNt",
-                PENCRYPTED_LM_OWF_PASSWORD(),
-                PENCRYPTED_LM_OWF_PASSWORD,
-            )
+        NDRPacketField(
+            "NewLmEncryptedWithNewNt",
+            PENCRYPTED_LM_OWF_PASSWORD(),
+            PENCRYPTED_LM_OWF_PASSWORD,
         ),
     ]
 
@@ -4305,21 +4294,17 @@ class PSAMPR_ENCRYPTED_USER_PASSWORD(NDRPacket):
 
 class SamrOemChangePasswordUser2_Request(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("ServerName", PRPC_STRING(), PRPC_STRING)),
+        NDRPacketField("ServerName", PRPC_STRING(), PRPC_STRING),
         NDRPacketField("UserName", PRPC_STRING(), PRPC_STRING),
-        NDRFullPointerField(
-            NDRPacketField(
-                "NewPasswordEncryptedWithOldLm",
-                PSAMPR_ENCRYPTED_USER_PASSWORD(),
-                PSAMPR_ENCRYPTED_USER_PASSWORD,
-            )
+        NDRPacketField(
+            "NewPasswordEncryptedWithOldLm",
+            PSAMPR_ENCRYPTED_USER_PASSWORD(),
+            PSAMPR_ENCRYPTED_USER_PASSWORD,
         ),
-        NDRFullPointerField(
-            NDRPacketField(
-                "OldLmOwfPasswordEncryptedWithNewLm",
-                PENCRYPTED_LM_OWF_PASSWORD(),
-                PENCRYPTED_LM_OWF_PASSWORD,
-            )
+        NDRPacketField(
+            "OldLmOwfPasswordEncryptedWithNewLm",
+            PENCRYPTED_LM_OWF_PASSWORD(),
+            PENCRYPTED_LM_OWF_PASSWORD,
         ),
     ]
 
@@ -4330,38 +4315,28 @@ class SamrOemChangePasswordUser2_Response(NDRPacket):
 
 class SamrUnicodeChangePasswordUser2_Request(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(
-            NDRPacketField("ServerName", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING)
-        ),
+        NDRPacketField("ServerName", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING),
         NDRPacketField("UserName", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING),
-        NDRFullPointerField(
-            NDRPacketField(
-                "NewPasswordEncryptedWithOldNt",
-                PSAMPR_ENCRYPTED_USER_PASSWORD(),
-                PSAMPR_ENCRYPTED_USER_PASSWORD,
-            )
+        NDRPacketField(
+            "NewPasswordEncryptedWithOldNt",
+            PSAMPR_ENCRYPTED_USER_PASSWORD(),
+            PSAMPR_ENCRYPTED_USER_PASSWORD,
         ),
-        NDRFullPointerField(
-            NDRPacketField(
-                "OldNtOwfPasswordEncryptedWithNewNt",
-                PENCRYPTED_NT_OWF_PASSWORD(),
-                PENCRYPTED_NT_OWF_PASSWORD,
-            )
+        NDRPacketField(
+            "OldNtOwfPasswordEncryptedWithNewNt",
+            PENCRYPTED_NT_OWF_PASSWORD(),
+            PENCRYPTED_NT_OWF_PASSWORD,
         ),
         NDRByteField("LmPresent", 0),
-        NDRFullPointerField(
-            NDRPacketField(
-                "NewPasswordEncryptedWithOldLm",
-                PSAMPR_ENCRYPTED_USER_PASSWORD(),
-                PSAMPR_ENCRYPTED_USER_PASSWORD,
-            )
+        NDRPacketField(
+            "NewPasswordEncryptedWithOldLm",
+            PSAMPR_ENCRYPTED_USER_PASSWORD(),
+            PSAMPR_ENCRYPTED_USER_PASSWORD,
         ),
-        NDRFullPointerField(
-            NDRPacketField(
-                "OldLmOwfPasswordEncryptedWithNewNt",
-                PENCRYPTED_LM_OWF_PASSWORD(),
-                PENCRYPTED_LM_OWF_PASSWORD,
-            )
+        NDRPacketField(
+            "OldLmOwfPasswordEncryptedWithNewNt",
+            PENCRYPTED_LM_OWF_PASSWORD(),
+            PENCRYPTED_LM_OWF_PASSWORD,
         ),
     ]
 
@@ -4371,11 +4346,7 @@ class SamrUnicodeChangePasswordUser2_Response(NDRPacket):
 
 
 class SamrGetDomainPasswordInformation_Request(NDRPacket):
-    fields_desc = [
-        NDRFullPointerField(
-            NDRPacketField("Unused", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING)
-        )
-    ]
+    fields_desc = [NDRPacketField("Unused", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING)]
 
 
 class SamrGetDomainPasswordInformation_Response(NDRPacket):
@@ -4930,16 +4901,12 @@ class SamrRidToSid_Response(NDRPacket):
 
 class SamrSetDSRMPassword_Request(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(
-            NDRPacketField("Unused", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING)
-        ),
+        NDRPacketField("Unused", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING),
         NDRIntField("UserId", 0),
-        NDRFullPointerField(
-            NDRPacketField(
-                "EncryptedNtOwfPassword",
-                PENCRYPTED_NT_OWF_PASSWORD(),
-                PENCRYPTED_NT_OWF_PASSWORD,
-            )
+        NDRPacketField(
+            "EncryptedNtOwfPassword",
+            PENCRYPTED_NT_OWF_PASSWORD(),
+            PENCRYPTED_NT_OWF_PASSWORD,
         ),
     ]
 
@@ -5212,9 +5179,7 @@ class PSAMPR_ENCRYPTED_PASSWORD_AES(NDRPacket):
 
 class SamrUnicodeChangePasswordUser4_Request(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(
-            NDRPacketField("ServerName", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING)
-        ),
+        NDRPacketField("ServerName", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING),
         NDRPacketField("UserName", PRPC_UNICODE_STRING(), PRPC_UNICODE_STRING),
         NDRPacketField(
             "EncryptedPassword",

--- a/scapy-rpc/msrpcs/ms_scmp.py
+++ b/scapy-rpc/msrpcs/ms_scmp.py
@@ -104,7 +104,7 @@ class QueryVolumesSupportedForSnapshots_Response(NDRPacket):
 
 class QuerySnapshotsByVolume_Request(NDRPacket):
     fields_desc = [
-        NDRConfVarStrNullFieldUtf16("pwszVolumeName", ""),
+        NDRFullPointerField(NDRConfVarStrNullFieldUtf16("pwszVolumeName", "")),
         NDRPacketField("ProviderId", GUID(), GUID),
     ]
 
@@ -137,8 +137,8 @@ register_com_interface(
 
 class AddDiffArea_Request(NDRPacket):
     fields_desc = [
-        NDRConfVarStrNullFieldUtf16("pwszVolumeName", ""),
-        NDRConfVarStrNullFieldUtf16("pwszDiffAreaVolumeName", ""),
+        NDRFullPointerField(NDRConfVarStrNullFieldUtf16("pwszVolumeName", "")),
+        NDRFullPointerField(NDRConfVarStrNullFieldUtf16("pwszDiffAreaVolumeName", "")),
         NDRSignedLongField("llMaximumDiffSpace", 0),
     ]
 
@@ -149,8 +149,8 @@ class AddDiffArea_Response(NDRPacket):
 
 class ChangeDiffAreaMaximumSize_Request(NDRPacket):
     fields_desc = [
-        NDRConfVarStrNullFieldUtf16("pwszVolumeName", ""),
-        NDRConfVarStrNullFieldUtf16("pwszDiffAreaVolumeName", ""),
+        NDRFullPointerField(NDRConfVarStrNullFieldUtf16("pwszVolumeName", "")),
+        NDRFullPointerField(NDRConfVarStrNullFieldUtf16("pwszDiffAreaVolumeName", "")),
         NDRSignedLongField("llMaximumDiffSpace", 0),
     ]
 
@@ -160,7 +160,9 @@ class ChangeDiffAreaMaximumSize_Response(NDRPacket):
 
 
 class QueryVolumesSupportedForDiffAreas_Request(NDRPacket):
-    fields_desc = [NDRConfVarStrNullFieldUtf16("pwszOriginalVolumeName", "")]
+    fields_desc = [
+        NDRFullPointerField(NDRConfVarStrNullFieldUtf16("pwszOriginalVolumeName", ""))
+    ]
 
 
 class QueryVolumesSupportedForDiffAreas_Response(NDRPacket):
@@ -173,7 +175,9 @@ class QueryVolumesSupportedForDiffAreas_Response(NDRPacket):
 
 
 class QueryDiffAreasForVolume_Request(NDRPacket):
-    fields_desc = [NDRConfVarStrNullFieldUtf16("pwszVolumeName", "")]
+    fields_desc = [
+        NDRFullPointerField(NDRConfVarStrNullFieldUtf16("pwszVolumeName", ""))
+    ]
 
 
 class QueryDiffAreasForVolume_Response(NDRPacket):
@@ -186,7 +190,9 @@ class QueryDiffAreasForVolume_Response(NDRPacket):
 
 
 class QueryDiffAreasOnVolume_Request(NDRPacket):
-    fields_desc = [NDRConfVarStrNullFieldUtf16("pwszVolumeName", "")]
+    fields_desc = [
+        NDRFullPointerField(NDRConfVarStrNullFieldUtf16("pwszVolumeName", ""))
+    ]
 
 
 class QueryDiffAreasOnVolume_Response(NDRPacket):

--- a/scapy-rpc/msrpcs/ms_scmr.py
+++ b/scapy-rpc/msrpcs/ms_scmr.py
@@ -450,10 +450,8 @@ class RStartServiceW_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("hService", NDRContextHandle(), NDRContextHandle),
         NDRIntField("argc", None, size_of="argv"),
-        NDRFullPointerField(
-            NDRConfPacketListField(
-                "argv", [], LPSTRING_PTRSW, size_is=lambda pkt: pkt.argc
-            )
+        NDRConfPacketListField(
+            "argv", [], LPSTRING_PTRSW, size_is=lambda pkt: pkt.argc
         ),
     ]
 
@@ -775,10 +773,8 @@ class RStartServiceA_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("hService", NDRContextHandle(), NDRContextHandle),
         NDRIntField("argc", None, size_of="argv"),
-        NDRFullPointerField(
-            NDRConfPacketListField(
-                "argv", [], LPSTRING_PTRSA, size_is=lambda pkt: pkt.argc
-            )
+        NDRConfPacketListField(
+            "argv", [], LPSTRING_PTRSA, size_is=lambda pkt: pkt.argc
         ),
     ]
 

--- a/scapy-rpc/msrpcs/ms_srvs.py
+++ b/scapy-rpc/msrpcs/ms_srvs.py
@@ -29,6 +29,7 @@ from scapy.layers.dcerpc import (
     NDRFullPointerField,
     NDRIntField,
     NDRPacketField,
+    NDRRefEmbPointerField,
     NDRShortField,
     NDRSignedIntField,
     NDRUnionField,
@@ -2920,7 +2921,7 @@ class PSERVER_XPORT_INFO_0_CONTAINER(NDRPacket):
     ALIGNMENT = (4, 8)
     fields_desc = [
         NDRIntField("EntriesRead", None, size_of="Buffer"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "Buffer",
                 [],
@@ -3670,9 +3671,7 @@ class NetrDfsManagerReportSiteInfo_Request(NDRPacket):
     fields_desc = [
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("ServerName", "")),
         NDRFullPointerField(
-            NDRFullPointerField(
-                NDRPacketField("ppSiteInfo", LPDFS_SITELIST_INFO(), LPDFS_SITELIST_INFO)
-            )
+            NDRPacketField("ppSiteInfo", LPDFS_SITELIST_INFO(), LPDFS_SITELIST_INFO)
         ),
     ]
 
@@ -3680,9 +3679,7 @@ class NetrDfsManagerReportSiteInfo_Request(NDRPacket):
 class NetrDfsManagerReportSiteInfo_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRFullPointerField(
-                NDRPacketField("ppSiteInfo", LPDFS_SITELIST_INFO(), LPDFS_SITELIST_INFO)
-            )
+            NDRPacketField("ppSiteInfo", LPDFS_SITELIST_INFO(), LPDFS_SITELIST_INFO)
         ),
         NDRIntField("status", 0),
     ]

--- a/scapy-rpc/msrpcs/ms_tsch_SchRpc.py
+++ b/scapy-rpc/msrpcs/ms_tsch_SchRpc.py
@@ -296,8 +296,8 @@ class PSYSTEMTIME(NDRPacket):
 class SchRpcScheduledRuntimes_Request(NDRPacket):
     fields_desc = [
         NDRConfVarStrNullFieldUtf16("path", ""),
-        NDRFullPointerField(NDRPacketField("start", PSYSTEMTIME(), PSYSTEMTIME)),
-        NDRFullPointerField(NDRPacketField("end", PSYSTEMTIME(), PSYSTEMTIME)),
+        NDRPacketField("start", PSYSTEMTIME(), PSYSTEMTIME),
+        NDRPacketField("end", PSYSTEMTIME(), PSYSTEMTIME),
         NDRIntField("flags", 0),
         NDRIntField("cRequested", 0),
     ]
@@ -307,11 +307,7 @@ class SchRpcScheduledRuntimes_Response(NDRPacket):
     fields_desc = [
         NDRIntField("pcRuntimes", None, size_of="pRuntimes"),
         NDRConfPacketListField(
-            "pRuntimes",
-            [],
-            PSYSTEMTIME,
-            size_is=lambda pkt: pkt.pcRuntimes,
-            ptr_pack=True,
+            "pRuntimes", [], PSYSTEMTIME, size_is=lambda pkt: pkt.pcRuntimes
         ),
         NDRIntField("status", 0),
     ]

--- a/scapy-rpc/msrpcs/ms_tsrap.py
+++ b/scapy-rpc/msrpcs/ms_tsrap.py
@@ -1012,12 +1012,14 @@ class Invoke_Request(NDRPacket):
         NDRConfFieldListField(
             "rgVarRefIdx", [], NDRIntField("", 0), size_is=lambda pkt: pkt.cVarRef
         ),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
     ]
 
@@ -1025,16 +1027,20 @@ class Invoke_Request(NDRPacket):
 class Invoke_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRPacketField("pExcepInfo", EXCEPINFO(), EXCEPINFO),
         NDRIntField("pArgErr", 0),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1062,7 +1068,9 @@ class GetTelnetSessions_Request(NDRPacket):
 class GetTelnetSessions_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pszSessionData", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pszSessionData", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1079,7 +1087,9 @@ class TerminateSession_Response(NDRPacket):
 class SendMsgToASession_Request(NDRPacket):
     fields_desc = [
         NDRIntField("dwUniqueId", 0),
-        NDRPacketField("szMsg", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("szMsg", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 

--- a/scapy-rpc/msrpcs/ms_tsts_legacy.py
+++ b/scapy-rpc/msrpcs/ms_tsts_legacy.py
@@ -494,7 +494,6 @@ class RpcWinStationGetAllProcesses_Response(NDRPacket):
             [],
             PTS_ALL_PROCESSES_INFO,
             size_is=lambda pkt: pkt.pNumberOfProcesses,
-            ptr_pack=True,
         ),
         NDRIntField("status", 0),
     ]
@@ -772,7 +771,6 @@ class RpcWinStationGetAllProcesses_NT6_Response(NDRPacket):
             [],
             PTS_ALL_PROCESSES_INFO_NT6,
             size_is=lambda pkt: pkt.pNumberOfProcesses,
-            ptr_pack=True,
         ),
         NDRIntField("status", 0),
     ]

--- a/scapy-rpc/msrpcs/ms_tsts_rcmpublic.py
+++ b/scapy-rpc/msrpcs/ms_tsts_rcmpublic.py
@@ -199,11 +199,7 @@ class RpcGetAllListeners_Request(NDRPacket):
 class RpcGetAllListeners_Response(NDRPacket):
     fields_desc = [
         NDRConfPacketListField(
-            "ppListeners",
-            [],
-            PLISTENERENUM,
-            size_is=lambda pkt: pkt.pNumListeners,
-            ptr_pack=True,
+            "ppListeners", [], PLISTENERENUM, size_is=lambda pkt: pkt.pNumListeners
         ),
         NDRIntField("pNumListeners", None, size_of="ppListeners"),
         NDRIntField("status", 0),

--- a/scapy-rpc/msrpcs/ms_tsts_tspubrpc.py
+++ b/scapy-rpc/msrpcs/ms_tsts_tspubrpc.py
@@ -543,11 +543,7 @@ class RpcGetEnumResult_Request(NDRPacket):
 class RpcGetEnumResult_Response(NDRPacket):
     fields_desc = [
         NDRConfPacketListField(
-            "ppSessionEnumResult",
-            [],
-            PSESSIONENUM,
-            size_is=lambda pkt: pkt.pEntries,
-            ptr_pack=True,
+            "ppSessionEnumResult", [], PSESSIONENUM, size_is=lambda pkt: pkt.pEntries
         ),
         NDRIntField("pEntries", None, size_of="ppSessionEnumResult"),
         NDRIntField("status", 0),
@@ -653,11 +649,7 @@ class RpcGetEnumResultEx_Request(NDRPacket):
 class RpcGetEnumResultEx_Response(NDRPacket):
     fields_desc = [
         NDRConfPacketListField(
-            "ppSessionEnumResult",
-            [],
-            PSESSIONENUM_EX,
-            size_is=lambda pkt: pkt.pEntries,
-            ptr_pack=True,
+            "ppSessionEnumResult", [], PSESSIONENUM_EX, size_is=lambda pkt: pkt.pEntries
         ),
         NDRIntField("pEntries", None, size_of="ppSessionEnumResult"),
         NDRIntField("status", 0),
@@ -723,11 +715,7 @@ class RpcGetAllSessions_Response(NDRPacket):
     fields_desc = [
         NDRIntField("pLevel", 0),
         NDRConfPacketListField(
-            "ppSessionData",
-            [],
-            PEXECENVDATA,
-            size_is=lambda pkt: pkt.pcEntries,
-            ptr_pack=True,
+            "ppSessionData", [], PEXECENVDATA, size_is=lambda pkt: pkt.pcEntries
         ),
         NDRIntField("pcEntries", None, size_of="ppSessionData"),
         NDRIntField("status", 0),
@@ -788,11 +776,7 @@ class RpcGetAllSessionsEx_Request(NDRPacket):
 class RpcGetAllSessionsEx_Response(NDRPacket):
     fields_desc = [
         NDRConfPacketListField(
-            "ppSessionData",
-            [],
-            PEXECENVDATAEX,
-            size_is=lambda pkt: pkt.pcEntries,
-            ptr_pack=True,
+            "ppSessionData", [], PEXECENVDATAEX, size_is=lambda pkt: pkt.pcEntries
         ),
         NDRIntField("pcEntries", None, size_of="ppSessionData"),
         NDRIntField("status", 0),

--- a/scapy-rpc/msrpcs/ms_uamg.py
+++ b/scapy-rpc/msrpcs/ms_uamg.py
@@ -1056,12 +1056,14 @@ class Invoke_Request(NDRPacket):
         NDRConfFieldListField(
             "rgVarRefIdx", [], NDRIntField("", 0), size_is=lambda pkt: pkt.cVarRef
         ),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
     ]
 
@@ -1069,16 +1071,20 @@ class Invoke_Request(NDRPacket):
 class Invoke_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRPacketField("pExcepInfo", EXCEPINFO(), EXCEPINFO),
         NDRIntField("pArgErr", 0),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1288,7 +1294,9 @@ class get_IUpdate_Title_Request(NDRPacket):
 class get_IUpdate_Title_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1342,7 +1350,11 @@ class get_IUpdate_Deadline_Request(NDRPacket):
 
 class get_IUpdate_Deadline_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("retval", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("retval", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
@@ -1370,7 +1382,9 @@ class get_IUpdate_Description_Request(NDRPacket):
 class get_IUpdate_Description_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1391,7 +1405,9 @@ class get_IUpdate_EulaText_Request(NDRPacket):
 class get_IUpdate_EulaText_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1404,7 +1420,9 @@ class get_IUpdate_HandlerID_Request(NDRPacket):
 class get_IUpdate_HandlerID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1560,7 +1578,9 @@ class get_IUpdate_MsrcSeverity_Request(NDRPacket):
 class get_IUpdate_MsrcSeverity_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1597,7 +1617,9 @@ class get_IUpdate_ReleaseNotes_Request(NDRPacket):
 class get_IUpdate_ReleaseNotes_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1636,7 +1658,9 @@ class get_IUpdate_SupportUrl_Request(NDRPacket):
 class get_IUpdate_SupportUrl_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1662,7 +1686,9 @@ class get_IUpdate_UninstallationNotes_Request(NDRPacket):
 class get_IUpdate_UninstallationNotes_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1884,7 +1910,11 @@ class get_IUpdateServiceManager_Services_Response(NDRPacket):
 
 
 class RegisterServiceWithAU_Request(NDRPacket):
-    fields_desc = [NDRPacketField("serviceID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("serviceID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class RegisterServiceWithAU_Response(NDRPacket):
@@ -1892,7 +1922,11 @@ class RegisterServiceWithAU_Response(NDRPacket):
 
 
 class RemoveService_Request(NDRPacket):
-    fields_desc = [NDRPacketField("serviceID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("serviceID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class RemoveService_Response(NDRPacket):
@@ -1901,8 +1935,12 @@ class RemoveService_Response(NDRPacket):
 
 class AddScanPackageService_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("serviceName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("scanFileLocation", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("serviceName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("scanFileLocation", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("flags", 0),
     ]
 
@@ -1918,8 +1956,12 @@ class AddScanPackageService_Response(NDRPacket):
 
 class SetOption_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("optionName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("optionValue", wireVARIANTStr(), wireVARIANTStr),
+        NDRFullPointerField(
+            NDRPacketField("optionName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("optionValue", wireVARIANTStr(), wireVARIANTStr)
+        ),
     ]
 
 
@@ -1959,14 +2001,20 @@ class get_IUpdateServiceManager2_ClientApplicationID_Request(NDRPacket):
 class get_IUpdateServiceManager2_ClientApplicationID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IUpdateServiceManager2_ClientApplicationID_Request(NDRPacket):
-    fields_desc = [NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IUpdateServiceManager2_ClientApplicationID_Response(NDRPacket):
@@ -1974,7 +2022,11 @@ class put_IUpdateServiceManager2_ClientApplicationID_Response(NDRPacket):
 
 
 class QueryServiceRegistration_Request(NDRPacket):
-    fields_desc = [NDRPacketField("serviceID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("serviceID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class QueryServiceRegistration_Response(NDRPacket):
@@ -1988,9 +2040,15 @@ class QueryServiceRegistration_Response(NDRPacket):
 
 class AddService2_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("serviceID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("serviceID", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("flags", 0),
-        NDRPacketField("authorizationCabPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField(
+                "authorizationCabPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
     ]
 
 
@@ -2045,7 +2103,9 @@ class get_IStringCollection_Item_Request(NDRPacket):
 class get_IStringCollection_Item_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2054,7 +2114,9 @@ class get_IStringCollection_Item_Response(NDRPacket):
 class put_IStringCollection_Item_Request(NDRPacket):
     fields_desc = [
         NDRSignedIntField("index", 0),
-        NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -2092,7 +2154,11 @@ class get_IStringCollection_ReadOnly_Response(NDRPacket):
 
 
 class Add_Request(NDRPacket):
-    fields_desc = [NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class Add_Response(NDRPacket):
@@ -2123,7 +2189,9 @@ class Copy_Response(NDRPacket):
 class Insert_Request(NDRPacket):
     fields_desc = [
         NDRSignedIntField("index", 0),
-        NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -2176,13 +2244,19 @@ register_com_interface(
 
 class GetInfo_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("varInfoIdentifier", wireVARIANTStr(), wireVARIANTStr)
+        NDRFullPointerField(
+            NDRPacketField("varInfoIdentifier", wireVARIANTStr(), wireVARIANTStr)
+        )
     ]
 
 
 class GetInfo_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("retval", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("retval", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
@@ -2209,7 +2283,11 @@ class get_IAutomaticUpdatesResults_LastSearchSuccessDate_Request(NDRPacket):
 
 class get_IAutomaticUpdatesResults_LastSearchSuccessDate_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("retval", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("retval", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
@@ -2220,7 +2298,11 @@ class get_IAutomaticUpdatesResults_LastInstallationSuccessDate_Request(NDRPacket
 
 class get_IAutomaticUpdatesResults_LastInstallationSuccessDate_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("retval", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("retval", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
@@ -2331,7 +2413,9 @@ class get_IUpdateIdentity_UpdateID_Request(NDRPacket):
 class get_IUpdateIdentity_UpdateID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2366,7 +2450,9 @@ class get_IImageInformation_AltText_Request(NDRPacket):
 class get_IImageInformation_AltText_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2387,7 +2473,9 @@ class get_IImageInformation_Source_Request(NDRPacket):
 class get_IImageInformation_Source_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2435,7 +2523,9 @@ class get_ICategory_Name_Request(NDRPacket):
 class get_ICategory_Name_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2448,7 +2538,9 @@ class get_ICategory_CategoryID_Request(NDRPacket):
 class get_ICategory_CategoryID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2474,7 +2566,9 @@ class get_ICategory_Description_Request(NDRPacket):
 class get_ICategory_Description_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2521,7 +2615,9 @@ class get_ICategory_Type_Request(NDRPacket):
 class get_ICategory_Type_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2652,7 +2748,9 @@ class get_IUpdateDownloadContent_DownloadUrl_Request(NDRPacket):
 class get_IUpdateDownloadContent_DownloadUrl_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2776,7 +2874,9 @@ class get_IWindowsDriverUpdate_DriverClass_Request(NDRPacket):
 class get_IWindowsDriverUpdate_DriverClass_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2789,7 +2889,9 @@ class get_IWindowsDriverUpdate_DriverHardwareID_Request(NDRPacket):
 class get_IWindowsDriverUpdate_DriverHardwareID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2802,7 +2904,9 @@ class get_IWindowsDriverUpdate_DriverManufacturer_Request(NDRPacket):
 class get_IWindowsDriverUpdate_DriverManufacturer_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2815,7 +2919,9 @@ class get_IWindowsDriverUpdate_DriverModel_Request(NDRPacket):
 class get_IWindowsDriverUpdate_DriverModel_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2828,7 +2934,9 @@ class get_IWindowsDriverUpdate_DriverProvider_Request(NDRPacket):
 class get_IWindowsDriverUpdate_DriverProvider_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -3580,7 +3688,9 @@ class get_IWindowsDriverUpdateEntry_DriverClass_Request(NDRPacket):
 class get_IWindowsDriverUpdateEntry_DriverClass_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -3593,7 +3703,9 @@ class get_IWindowsDriverUpdateEntry_DriverHardwareID_Request(NDRPacket):
 class get_IWindowsDriverUpdateEntry_DriverHardwareID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -3606,7 +3718,9 @@ class get_IWindowsDriverUpdateEntry_DriverManufacturer_Request(NDRPacket):
 class get_IWindowsDriverUpdateEntry_DriverManufacturer_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -3619,7 +3733,9 @@ class get_IWindowsDriverUpdateEntry_DriverModel_Request(NDRPacket):
 class get_IWindowsDriverUpdateEntry_DriverModel_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -3632,7 +3748,9 @@ class get_IWindowsDriverUpdateEntry_DriverProvider_Request(NDRPacket):
 class get_IWindowsDriverUpdateEntry_DriverProvider_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -4529,7 +4647,9 @@ class get_IUpdateException_Message_Request(NDRPacket):
 class get_IUpdateException_Message_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -4793,7 +4913,9 @@ class get_IUpdateHistoryEntry_Title_Request(NDRPacket):
 class get_IUpdateHistoryEntry_Title_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -4806,7 +4928,9 @@ class get_IUpdateHistoryEntry_Description_Request(NDRPacket):
 class get_IUpdateHistoryEntry_Description_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -4827,7 +4951,9 @@ class get_IUpdateHistoryEntry_ClientApplicationID_Request(NDRPacket):
 class get_IUpdateHistoryEntry_ClientApplicationID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -4858,7 +4984,9 @@ class get_IUpdateHistoryEntry_ServiceID_Request(NDRPacket):
 class get_IUpdateHistoryEntry_ServiceID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -4884,7 +5012,9 @@ class get_IUpdateHistoryEntry_UninstallationNotes_Request(NDRPacket):
 class get_IUpdateHistoryEntry_UninstallationNotes_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -4897,7 +5027,9 @@ class get_IUpdateHistoryEntry_SupportUrl_Request(NDRPacket):
 class get_IUpdateHistoryEntry_SupportUrl_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -5142,14 +5274,20 @@ class get_IUpdateSearcher_ClientApplicationID_Request(NDRPacket):
 class get_IUpdateSearcher_ClientApplicationID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IUpdateSearcher_ClientApplicationID_Request(NDRPacket):
-    fields_desc = [NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IUpdateSearcher_ClientApplicationID_Response(NDRPacket):
@@ -5192,13 +5330,19 @@ class put_IUpdateSearcher_ServerSelection_Response(NDRPacket):
 
 
 class EscapeString_Request(NDRPacket):
-    fields_desc = [NDRPacketField("unescaped", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("unescaped", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class EscapeString_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -5218,7 +5362,11 @@ class QueryHistory_Response(NDRPacket):
 
 
 class Search_Request(NDRPacket):
-    fields_desc = [NDRPacketField("criteria", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("criteria", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class Search_Response(NDRPacket):
@@ -5261,14 +5409,20 @@ class get_IUpdateSearcher_ServiceID_Request(NDRPacket):
 class get_IUpdateSearcher_ServiceID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IUpdateSearcher_ServiceID_Request(NDRPacket):
-    fields_desc = [NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IUpdateSearcher_ServiceID_Response(NDRPacket):
@@ -5542,14 +5696,20 @@ class get_IUpdateSession_ClientApplicationID_Request(NDRPacket):
 class get_IUpdateSession_ClientApplicationID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
 
 
 class put_IUpdateSession_ClientApplicationID_Request(NDRPacket):
-    fields_desc = [NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)]
+    fields_desc = [
+        NDRFullPointerField(
+            NDRPacketField("value", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
+    ]
 
 
 class put_IUpdateSession_ClientApplicationID_Response(NDRPacket):
@@ -5676,7 +5836,9 @@ class CreateUpdateServiceManager_Response(NDRPacket):
 
 class QueryHistory_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("criteria", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("criteria", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("startIndex", 0),
         NDRSignedIntField("count", 0),
     ]
@@ -5739,7 +5901,9 @@ class get_IUpdateService_Name_Request(NDRPacket):
 class get_IUpdateService_Name_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -5751,7 +5915,11 @@ class get_IUpdateService_ContentValidationCert_Request(NDRPacket):
 
 class get_IUpdateService_ContentValidationCert_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("retval", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("retval", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
@@ -5816,7 +5984,9 @@ class get_IUpdateService_ServiceID_Request(NDRPacket):
 class get_IUpdateService_ServiceID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -5845,7 +6015,9 @@ class get_IUpdateService_ServiceUrl_Request(NDRPacket):
 class get_IUpdateService_ServiceUrl_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -5858,7 +6030,9 @@ class get_IUpdateService_SetupPrefix_Request(NDRPacket):
 class get_IUpdateService_SetupPrefix_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -6079,7 +6253,9 @@ class get_IUpdateServiceRegistration_ServiceID_Request(NDRPacket):
 class get_IUpdateServiceRegistration_ServiceID_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("retval", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]

--- a/scapy-rpc/msrpcs/ms_vds.py
+++ b/scapy-rpc/msrpcs/ms_vds.py
@@ -3303,7 +3303,6 @@ class QueryReparsePoints_Response(NDRPacket):
             [],
             PVDS_REPARSE_POINT_PROP,
             size_is=lambda pkt: pkt.plNumberOfReparsePointProps,
-            ptr_pack=True,
         ),
         NDRSignedIntField(
             "plNumberOfReparsePointProps", None, size_of="ppReparsePointProps"

--- a/scapy-rpc/msrpcs/ms_w32t.py
+++ b/scapy-rpc/msrpcs/ms_w32t.py
@@ -26,6 +26,7 @@ from scapy.layers.dcerpc import (
     NDRIntField,
     NDRLongField,
     NDRPacketField,
+    NDRRefEmbPointerField,
     NDRSignedIntField,
     NDRSignedLongField,
     NDRUnionField,
@@ -390,13 +391,12 @@ class PW32TIME_CONFIGURATION_INFO(NDRPacket):
             W32TIME_CONFIGURATION_DEFAULT,
         ),
         NDRIntField("cProviderConfig", None, size_of="pProviderConfig"),
-        NDRFullEmbPointerField(
+        NDRRefEmbPointerField(
             NDRConfPacketListField(
                 "pProviderConfig",
                 [],
                 PW32TIME_CONFIGURATION_PROVIDER,
                 size_is=lambda pkt: pkt.cProviderConfig,
-                ptr_pack=True,
             )
         ),
         NDRIntField("cEntries", None, size_of="pEntries"),

--- a/scapy-rpc/msrpcs/ms_wkst.py
+++ b/scapy-rpc/msrpcs/ms_wkst.py
@@ -513,8 +513,10 @@ class NetrWkstaTransportAdd_Request(NDRPacket):
     fields_desc = [
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("ServerName", "")),
         NDRIntField("Level", 0),
-        NDRPacketField(
-            "TransportInfo", LPWKSTA_TRANSPORT_INFO_0(), LPWKSTA_TRANSPORT_INFO_0
+        NDRFullPointerField(
+            NDRPacketField(
+                "TransportInfo", LPWKSTA_TRANSPORT_INFO_0(), LPWKSTA_TRANSPORT_INFO_0
+            )
         ),
         NDRFullPointerField(NDRIntField("ErrorParameter", 0)),
     ]
@@ -916,12 +918,10 @@ class NetrJoinDomain2_Request(NDRPacket):
         NDRConfVarStrNullFieldUtf16("DomainNameParam", ""),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("MachineAccountOU", "")),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("AccountName", "")),
-        NDRFullPointerField(
-            NDRPacketField(
-                "Password",
-                PJOINPR_ENCRYPTED_USER_PASSWORD(),
-                PJOINPR_ENCRYPTED_USER_PASSWORD,
-            )
+        NDRPacketField(
+            "Password",
+            PJOINPR_ENCRYPTED_USER_PASSWORD(),
+            PJOINPR_ENCRYPTED_USER_PASSWORD,
         ),
         NDRIntField("Options", 0),
     ]
@@ -935,12 +935,10 @@ class NetrUnjoinDomain2_Request(NDRPacket):
     fields_desc = [
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("ServerName", "")),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("AccountName", "")),
-        NDRFullPointerField(
-            NDRPacketField(
-                "Password",
-                PJOINPR_ENCRYPTED_USER_PASSWORD(),
-                PJOINPR_ENCRYPTED_USER_PASSWORD,
-            )
+        NDRPacketField(
+            "Password",
+            PJOINPR_ENCRYPTED_USER_PASSWORD(),
+            PJOINPR_ENCRYPTED_USER_PASSWORD,
         ),
         NDRIntField("Options", 0),
     ]
@@ -955,12 +953,10 @@ class NetrRenameMachineInDomain2_Request(NDRPacket):
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("ServerName", "")),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("MachineName", "")),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("AccountName", "")),
-        NDRFullPointerField(
-            NDRPacketField(
-                "Password",
-                PJOINPR_ENCRYPTED_USER_PASSWORD(),
-                PJOINPR_ENCRYPTED_USER_PASSWORD,
-            )
+        NDRPacketField(
+            "Password",
+            PJOINPR_ENCRYPTED_USER_PASSWORD(),
+            PJOINPR_ENCRYPTED_USER_PASSWORD,
         ),
         NDRIntField("Options", 0),
     ]
@@ -984,12 +980,10 @@ class NetrValidateName2_Request(NDRPacket):
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("ServerName", "")),
         NDRConfVarStrNullFieldUtf16("NameToValidate", ""),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("AccountName", "")),
-        NDRFullPointerField(
-            NDRPacketField(
-                "Password",
-                PJOINPR_ENCRYPTED_USER_PASSWORD(),
-                PJOINPR_ENCRYPTED_USER_PASSWORD,
-            )
+        NDRPacketField(
+            "Password",
+            PJOINPR_ENCRYPTED_USER_PASSWORD(),
+            PJOINPR_ENCRYPTED_USER_PASSWORD,
         ),
         NDRInt3264EnumField("NameType", 0, NETSETUP_NAME_TYPE),
     ]
@@ -1004,12 +998,10 @@ class NetrGetJoinableOUs2_Request(NDRPacket):
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("ServerName", "")),
         NDRConfVarStrNullFieldUtf16("DomainNameParam", ""),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("AccountName", "")),
-        NDRFullPointerField(
-            NDRPacketField(
-                "Password",
-                PJOINPR_ENCRYPTED_USER_PASSWORD(),
-                PJOINPR_ENCRYPTED_USER_PASSWORD,
-            )
+        NDRPacketField(
+            "Password",
+            PJOINPR_ENCRYPTED_USER_PASSWORD(),
+            PJOINPR_ENCRYPTED_USER_PASSWORD,
         ),
         NDRIntField("OUCount", 0),
     ]
@@ -1028,12 +1020,10 @@ class NetrAddAlternateComputerName_Request(NDRPacket):
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("ServerName", "")),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("AlternateName", "")),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("DomainAccount", "")),
-        NDRFullPointerField(
-            NDRPacketField(
-                "EncryptedPassword",
-                PJOINPR_ENCRYPTED_USER_PASSWORD(),
-                PJOINPR_ENCRYPTED_USER_PASSWORD,
-            )
+        NDRPacketField(
+            "EncryptedPassword",
+            PJOINPR_ENCRYPTED_USER_PASSWORD(),
+            PJOINPR_ENCRYPTED_USER_PASSWORD,
         ),
         NDRIntField("Reserved", 0),
     ]
@@ -1048,12 +1038,10 @@ class NetrRemoveAlternateComputerName_Request(NDRPacket):
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("ServerName", "")),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("AlternateName", "")),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("DomainAccount", "")),
-        NDRFullPointerField(
-            NDRPacketField(
-                "EncryptedPassword",
-                PJOINPR_ENCRYPTED_USER_PASSWORD(),
-                PJOINPR_ENCRYPTED_USER_PASSWORD,
-            )
+        NDRPacketField(
+            "EncryptedPassword",
+            PJOINPR_ENCRYPTED_USER_PASSWORD(),
+            PJOINPR_ENCRYPTED_USER_PASSWORD,
         ),
         NDRIntField("Reserved", 0),
     ]
@@ -1068,12 +1056,10 @@ class NetrSetPrimaryComputerName_Request(NDRPacket):
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("ServerName", "")),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("PrimaryName", "")),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("DomainAccount", "")),
-        NDRFullPointerField(
-            NDRPacketField(
-                "EncryptedPassword",
-                PJOINPR_ENCRYPTED_USER_PASSWORD(),
-                PJOINPR_ENCRYPTED_USER_PASSWORD,
-            )
+        NDRPacketField(
+            "EncryptedPassword",
+            PJOINPR_ENCRYPTED_USER_PASSWORD(),
+            PJOINPR_ENCRYPTED_USER_PASSWORD,
         ),
         NDRIntField("Reserved", 0),
     ]
@@ -1157,12 +1143,10 @@ class NetrJoinDomain3_Request(NDRPacket):
         NDRConfVarStrNullFieldUtf16("DomainNameParam", ""),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("MachineAccountOU", "")),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("AccountName", "")),
-        NDRFullPointerField(
-            NDRPacketField(
-                "Password",
-                PJOINPR_ENCRYPTED_USER_PASSWORD_AES(),
-                PJOINPR_ENCRYPTED_USER_PASSWORD_AES,
-            )
+        NDRPacketField(
+            "Password",
+            PJOINPR_ENCRYPTED_USER_PASSWORD_AES(),
+            PJOINPR_ENCRYPTED_USER_PASSWORD_AES,
         ),
         NDRIntField("Options", 0),
     ]
@@ -1176,12 +1160,10 @@ class NetrUnjoinDomain3_Request(NDRPacket):
     fields_desc = [
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("ServerName", "")),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("AccountName", "")),
-        NDRFullPointerField(
-            NDRPacketField(
-                "Password",
-                PJOINPR_ENCRYPTED_USER_PASSWORD_AES(),
-                PJOINPR_ENCRYPTED_USER_PASSWORD_AES,
-            )
+        NDRPacketField(
+            "Password",
+            PJOINPR_ENCRYPTED_USER_PASSWORD_AES(),
+            PJOINPR_ENCRYPTED_USER_PASSWORD_AES,
         ),
         NDRIntField("Options", 0),
     ]
@@ -1196,12 +1178,10 @@ class NetrRenameMachineInDomain3_Request(NDRPacket):
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("ServerName", "")),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("MachineName", "")),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("AccountName", "")),
-        NDRFullPointerField(
-            NDRPacketField(
-                "Password",
-                PJOINPR_ENCRYPTED_USER_PASSWORD(),
-                PJOINPR_ENCRYPTED_USER_PASSWORD,
-            )
+        NDRPacketField(
+            "Password",
+            PJOINPR_ENCRYPTED_USER_PASSWORD(),
+            PJOINPR_ENCRYPTED_USER_PASSWORD,
         ),
         NDRIntField("Options", 0),
     ]
@@ -1216,12 +1196,10 @@ class NetrValidateName3_Request(NDRPacket):
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("ServerName", "")),
         NDRConfVarStrNullFieldUtf16("NameToValidate", ""),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("AccountName", "")),
-        NDRFullPointerField(
-            NDRPacketField(
-                "Password",
-                PJOINPR_ENCRYPTED_USER_PASSWORD_AES(),
-                PJOINPR_ENCRYPTED_USER_PASSWORD_AES,
-            )
+        NDRPacketField(
+            "Password",
+            PJOINPR_ENCRYPTED_USER_PASSWORD_AES(),
+            PJOINPR_ENCRYPTED_USER_PASSWORD_AES,
         ),
         NDRInt3264EnumField("NameType", 0, NETSETUP_NAME_TYPE),
     ]
@@ -1236,12 +1214,10 @@ class NetrAddAlternateComputerName2_Request(NDRPacket):
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("ServerName", "")),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("AlternateName", "")),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("DomainAccount", "")),
-        NDRFullPointerField(
-            NDRPacketField(
-                "EncryptedPassword",
-                PJOINPR_ENCRYPTED_USER_PASSWORD_AES(),
-                PJOINPR_ENCRYPTED_USER_PASSWORD_AES,
-            )
+        NDRPacketField(
+            "EncryptedPassword",
+            PJOINPR_ENCRYPTED_USER_PASSWORD_AES(),
+            PJOINPR_ENCRYPTED_USER_PASSWORD_AES,
         ),
         NDRIntField("Reserved", 0),
     ]
@@ -1256,12 +1232,10 @@ class NetrRemoveAlternateComputerName2_Request(NDRPacket):
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("ServerName", "")),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("AlternateName", "")),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("DomainAccount", "")),
-        NDRFullPointerField(
-            NDRPacketField(
-                "EncryptedPassword",
-                PJOINPR_ENCRYPTED_USER_PASSWORD_AES(),
-                PJOINPR_ENCRYPTED_USER_PASSWORD_AES,
-            )
+        NDRPacketField(
+            "EncryptedPassword",
+            PJOINPR_ENCRYPTED_USER_PASSWORD_AES(),
+            PJOINPR_ENCRYPTED_USER_PASSWORD_AES,
         ),
         NDRIntField("Reserved", 0),
     ]
@@ -1276,12 +1250,10 @@ class NetrSetPrimaryComputerName2_Request(NDRPacket):
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("ServerName", "")),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("PrimaryName", "")),
         NDRFullPointerField(NDRConfVarStrNullFieldUtf16("DomainAccount", "")),
-        NDRFullPointerField(
-            NDRPacketField(
-                "EncryptedPassword",
-                PJOINPR_ENCRYPTED_USER_PASSWORD(),
-                PJOINPR_ENCRYPTED_USER_PASSWORD,
-            )
+        NDRPacketField(
+            "EncryptedPassword",
+            PJOINPR_ENCRYPTED_USER_PASSWORD(),
+            PJOINPR_ENCRYPTED_USER_PASSWORD,
         ),
         NDRIntField("Reserved", 0),
     ]

--- a/scapy-rpc/msrpcs/ms_wmi.py
+++ b/scapy-rpc/msrpcs/ms_wmi.py
@@ -100,7 +100,9 @@ class MInterfacePointer(NDRPacket):
 
 class OpenNamespace_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("strNamespace", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("strNamespace", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("lFlags", 0),
         NDRPacketField("pCtx", MInterfacePointer(), MInterfacePointer),
         NDRFullPointerField(
@@ -159,7 +161,9 @@ class QueryObjectSink_Response(NDRPacket):
 
 class GetObject_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("strObjectPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("strObjectPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("lFlags", 0),
         NDRPacketField("pCtx", MInterfacePointer(), MInterfacePointer),
         NDRFullPointerField(
@@ -193,7 +197,9 @@ class GetObject_Response(NDRPacket):
 
 class GetObjectAsync_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("strObjectPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("strObjectPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("lFlags", 0),
         NDRPacketField("pCtx", MInterfacePointer(), MInterfacePointer),
         NDRPacketField("pResponseHandler", MInterfacePointer(), MInterfacePointer),
@@ -243,7 +249,9 @@ class PutClassAsync_Response(NDRPacket):
 
 class DeleteClass_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("strClass", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("strClass", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("lFlags", 0),
         NDRPacketField("pCtx", MInterfacePointer(), MInterfacePointer),
         NDRFullPointerField(
@@ -267,7 +275,9 @@ class DeleteClass_Response(NDRPacket):
 
 class DeleteClassAsync_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("strClass", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("strClass", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("lFlags", 0),
         NDRPacketField("pCtx", MInterfacePointer(), MInterfacePointer),
         NDRPacketField("pResponseHandler", MInterfacePointer(), MInterfacePointer),
@@ -280,7 +290,9 @@ class DeleteClassAsync_Response(NDRPacket):
 
 class CreateClassEnum_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("strSuperclass", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("strSuperclass", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("lFlags", 0),
         NDRPacketField("pCtx", MInterfacePointer(), MInterfacePointer),
     ]
@@ -297,7 +309,9 @@ class CreateClassEnum_Response(NDRPacket):
 
 class CreateClassEnumAsync_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("strSuperclass", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("strSuperclass", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("lFlags", 0),
         NDRPacketField("pCtx", MInterfacePointer(), MInterfacePointer),
         NDRPacketField("pResponseHandler", MInterfacePointer(), MInterfacePointer),
@@ -347,7 +361,9 @@ class PutInstanceAsync_Response(NDRPacket):
 
 class DeleteInstance_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("strObjectPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("strObjectPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("lFlags", 0),
         NDRPacketField("pCtx", MInterfacePointer(), MInterfacePointer),
         NDRFullPointerField(
@@ -371,7 +387,9 @@ class DeleteInstance_Response(NDRPacket):
 
 class DeleteInstanceAsync_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("strObjectPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("strObjectPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("lFlags", 0),
         NDRPacketField("pCtx", MInterfacePointer(), MInterfacePointer),
         NDRPacketField("pResponseHandler", MInterfacePointer(), MInterfacePointer),
@@ -384,7 +402,9 @@ class DeleteInstanceAsync_Response(NDRPacket):
 
 class CreateInstanceEnum_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("strSuperClass", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("strSuperClass", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("lFlags", 0),
         NDRPacketField("pCtx", MInterfacePointer(), MInterfacePointer),
     ]
@@ -401,7 +421,9 @@ class CreateInstanceEnum_Response(NDRPacket):
 
 class CreateInstanceEnumAsync_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("strSuperClass", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("strSuperClass", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("lFlags", 0),
         NDRPacketField("pCtx", MInterfacePointer(), MInterfacePointer),
         NDRPacketField("pResponseHandler", MInterfacePointer(), MInterfacePointer),
@@ -414,8 +436,12 @@ class CreateInstanceEnumAsync_Response(NDRPacket):
 
 class ExecQuery_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("strQueryLanguage", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("strQuery", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("strQueryLanguage", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("strQuery", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("lFlags", 0),
         NDRPacketField("pCtx", MInterfacePointer(), MInterfacePointer),
     ]
@@ -432,8 +458,12 @@ class ExecQuery_Response(NDRPacket):
 
 class ExecQueryAsync_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("strQueryLanguage", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("strQuery", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("strQueryLanguage", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("strQuery", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("lFlags", 0),
         NDRPacketField("pCtx", MInterfacePointer(), MInterfacePointer),
         NDRPacketField("pResponseHandler", MInterfacePointer(), MInterfacePointer),
@@ -446,8 +476,12 @@ class ExecQueryAsync_Response(NDRPacket):
 
 class ExecNotificationQuery_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("strQueryLanguage", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("strQuery", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("strQueryLanguage", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("strQuery", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("lFlags", 0),
         NDRPacketField("pCtx", MInterfacePointer(), MInterfacePointer),
     ]
@@ -464,8 +498,12 @@ class ExecNotificationQuery_Response(NDRPacket):
 
 class ExecNotificationQueryAsync_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("strQueryLanguage", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("strQuery", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("strQueryLanguage", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("strQuery", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("lFlags", 0),
         NDRPacketField("pCtx", MInterfacePointer(), MInterfacePointer),
         NDRPacketField("pResponseHandler", MInterfacePointer(), MInterfacePointer),
@@ -478,8 +516,12 @@ class ExecNotificationQueryAsync_Response(NDRPacket):
 
 class ExecMethod_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("strObjectPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("strMethodName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("strObjectPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("strMethodName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("lFlags", 0),
         NDRPacketField("pCtx", MInterfacePointer(), MInterfacePointer),
         NDRPacketField("pInParams", MInterfacePointer(), MInterfacePointer),
@@ -514,8 +556,12 @@ class ExecMethod_Response(NDRPacket):
 
 class ExecMethodAsync_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("strObjectPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("strMethodName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("strObjectPath", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("strMethodName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("lFlags", 0),
         NDRPacketField("pCtx", MInterfacePointer(), MInterfacePointer),
         NDRPacketField("pInParams", MInterfacePointer(), MInterfacePointer),
@@ -584,7 +630,9 @@ class SetStatus_Request(NDRPacket):
     fields_desc = [
         NDRSignedIntField("lFlags", 0),
         NDRSignedIntField("hResult", 0),
-        NDRPacketField("strParam", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("strParam", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRPacketField("pObjParam", MInterfacePointer(), MInterfacePointer),
     ]
 
@@ -701,7 +749,11 @@ class GetResultString_Request(NDRPacket):
 class GetResultString_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pstrResultString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pstrResultString", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]

--- a/scapy-rpc/msrpcs/ms_wsrm.py
+++ b/scapy-rpc/msrpcs/ms_wsrm.py
@@ -1022,12 +1022,14 @@ class Invoke_Request(NDRPacket):
         NDRConfFieldListField(
             "rgVarRefIdx", [], NDRIntField("", 0), size_is=lambda pkt: pkt.cVarRef
         ),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
     ]
 
@@ -1035,16 +1037,20 @@ class Invoke_Request(NDRPacket):
 class Invoke_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVarResult", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRPacketField("pExcepInfo", EXCEPINFO(), EXCEPINFO),
         NDRIntField("pArgErr", 0),
-        NDRConfPacketListField(
-            "rgVarRef",
-            [],
-            wireVARIANTStr,
-            size_is=lambda pkt: pkt.cVarRef,
-            ptr_pack=True,
+        NDRFullPointerField(
+            NDRConfPacketListField(
+                "rgVarRef",
+                [],
+                wireVARIANTStr,
+                size_is=lambda pkt: pkt.cVarRef,
+                ptr_pack=True,
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1072,7 +1078,9 @@ class RetrieveEventList_Request(NDRPacket):
 class RetrieveEventList_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrEventList", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrEventList", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1088,10 +1096,18 @@ class GetSystemAffinity_Response(NDRPacket):
 
 class ImportXMLFiles_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrPMCXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrPolicyXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrCalendarXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrConditionalXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrPMCXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrPolicyXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrCalendarXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrConditionalXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -1106,17 +1122,27 @@ class ExportXMLFiles_Request(NDRPacket):
 class ExportXMLFiles_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrPMCXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrPMCXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRFullPointerField(
-            NDRPacketField("pbstrPolicyXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrPolicyXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRFullPointerField(
-            NDRPacketField("pbstrCalendarXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrCalendarXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrConditionalXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrConditionalXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -1144,7 +1170,9 @@ class OBJECT_TYPE(IntEnum):
 
 class GetDependencies_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrObjectName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrObjectName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRIntEnumField("enumObject", 0, OBJECT_TYPE),
     ]
 
@@ -1152,8 +1180,10 @@ class GetDependencies_Request(NDRPacket):
 class GetDependencies_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrDependencyList", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrDependencyList", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -1167,7 +1197,11 @@ class GetServiceList_Request(NDRPacket):
 class GetServiceList_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrServiceList", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrServiceList", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1180,13 +1214,17 @@ class GetIISAppPoolNames_Request(NDRPacket):
 class GetIISAppPoolNames_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrIISAppPoolList", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrIISAppPoolList", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrSystemDirectory", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrSystemDirectory", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -1200,7 +1238,11 @@ class GetServerName_Request(NDRPacket):
 class GetServerName_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrServerName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrServerName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1241,14 +1283,20 @@ register_com_interface(
 
 class GetCalendarInfo_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrCalendarName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrCalendarName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
 class GetCalendarInfo_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrCalendarXML", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrCalendarXML", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1256,7 +1304,9 @@ class GetCalendarInfo_Response(NDRPacket):
 
 class CreateCalendar_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrCalendarXML", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrCalendarXML", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("bChangeActivePolicy", 0),
     ]
 
@@ -1267,7 +1317,9 @@ class CreateCalendar_Response(NDRPacket):
 
 class ModifyCalendar_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrCalendarXML", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrCalendarXML", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("bOverwrite", 0),
         NDRSignedIntField("bChangeActivePolicy", 0),
     ]
@@ -1279,7 +1331,9 @@ class ModifyCalendar_Response(NDRPacket):
 
 class DeleteCalendar_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrCalendarName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrCalendarName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("bChangeActivePolicy", 0),
     ]
 
@@ -1290,8 +1344,16 @@ class DeleteCalendar_Response(NDRPacket):
 
 class RenameCalendar_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrOldCalendarName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrNewCalendarName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrOldCalendarName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrNewCalendarName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
     ]
 
 
@@ -1301,8 +1363,12 @@ class RenameCalendar_Response(NDRPacket):
 
 class ComputeEvents_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("szStartTime", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("szEndTime", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("szStartTime", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("szEndTime", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("fMergeEvents", 0),
     ]
 
@@ -1310,10 +1376,14 @@ class ComputeEvents_Request(NDRPacket):
 class ComputeEvents_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrEvents", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrEvents", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRFullPointerField(
-            NDRPacketField("pbstrConflicts", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrConflicts", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1321,14 +1391,20 @@ class ComputeEvents_Response(NDRPacket):
 
 class GetScheduleInfo_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrScheduleName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrScheduleName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
 class GetScheduleInfo_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrScheduleXML", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrScheduleXML", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1336,7 +1412,9 @@ class GetScheduleInfo_Response(NDRPacket):
 
 class CreateSchedule_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrScheduleXML", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrScheduleXML", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1346,7 +1424,9 @@ class CreateSchedule_Response(NDRPacket):
 
 class ModifySchedule_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrScheduleXML", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrScheduleXML", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("bOverwrite", 0),
         NDRSignedIntField("bChangeActivePolicy", 0),
     ]
@@ -1358,7 +1438,9 @@ class ModifySchedule_Response(NDRPacket):
 
 class DeleteSchedule_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrScheduleName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrScheduleName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1368,8 +1450,16 @@ class DeleteSchedule_Response(NDRPacket):
 
 class RenameSchedule_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrOldScheduleName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrNewScheduleName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrOldScheduleName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrNewScheduleName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
     ]
 
 
@@ -1379,8 +1469,14 @@ class RenameSchedule_Response(NDRPacket):
 
 class MoveBeforeCalendar_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrCalendarName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrRefCalendarName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrCalendarName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrRefCalendarName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
         NDRSignedIntField("bChangeActivePolicy", 0),
     ]
 
@@ -1391,8 +1487,14 @@ class MoveBeforeCalendar_Response(NDRPacket):
 
 class MoveAfterCalendar_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrCalendarName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrRefCalendarName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrCalendarName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrRefCalendarName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
         NDRSignedIntField("bChangeActivePolicy", 0),
     ]
 
@@ -1440,14 +1542,20 @@ register_com_interface(
 
 class GetPolicyInfo_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrPolicyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrPolicyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
 class GetPolicyInfo_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrPolicyInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrPolicyInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1455,7 +1563,9 @@ class GetPolicyInfo_Response(NDRPacket):
 
 class CreatePolicy_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrPolicyInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrPolicyInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1465,7 +1575,9 @@ class CreatePolicy_Response(NDRPacket):
 
 class ModifyPolicy_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrPolicyInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrPolicyInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("bOverwrite", 0),
     ]
 
@@ -1476,7 +1588,9 @@ class ModifyPolicy_Response(NDRPacket):
 
 class DeletePolicy_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrPolicyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrPolicyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1486,8 +1600,12 @@ class DeletePolicy_Response(NDRPacket):
 
 class RenameAllocationPolicy_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrNewPolicyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrOldPolicyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrNewPolicyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrOldPolicyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -1497,10 +1615,18 @@ class RenameAllocationPolicy_Response(NDRPacket):
 
 class MoveBefore_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrPolicyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrResourceGroupName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField(
-            "bstrRefResourceGroupName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField("bstrPolicyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrResourceGroupName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrRefResourceGroupName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         ),
     ]
 
@@ -1511,10 +1637,18 @@ class MoveBefore_Response(NDRPacket):
 
 class MoveAfter_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrPolicyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrResourceGroupName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField(
-            "bstrRefResourceGroupName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField("bstrPolicyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrResourceGroupName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrRefResourceGroupName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         ),
     ]
 
@@ -1525,7 +1659,11 @@ class MoveAfter_Response(NDRPacket):
 
 class SetCalDefaultPolicyName_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrDefaultPolicyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrDefaultPolicyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        )
     ]
 
 
@@ -1540,8 +1678,10 @@ class GetCalDefaultPolicyName_Request(NDRPacket):
 class GetCalDefaultPolicyName_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrDefaultPolicyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrDefaultPolicyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -1550,14 +1690,20 @@ class GetCalDefaultPolicyName_Response(NDRPacket):
 
 class GetProcessList_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrPolicyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrPolicyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
 class GetProcessList_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrProcessList", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrProcessList", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1576,8 +1722,10 @@ class GetCurrentPolicy_Request(NDRPacket):
 class GetCurrentPolicy_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrCurrentPolicyInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrCurrentPolicyInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntEnumField("enumManage", 0, MANAGEMENT_TYPE),
@@ -1587,7 +1735,9 @@ class GetCurrentPolicy_Response(NDRPacket):
 
 class SetCurrentPolicy_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrPolicyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrPolicyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRIntEnumField("enumManage", 0, MANAGEMENT_TYPE),
     ]
 
@@ -1603,8 +1753,10 @@ class GetCurrentStateAndActivePolicyName_Request(NDRPacket):
 class GetCurrentStateAndActivePolicyName_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrCurrentPolicyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrCurrentPolicyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntEnumField("enumManage", 0, MANAGEMENT_TYPE),
@@ -1614,14 +1766,20 @@ class GetCurrentStateAndActivePolicyName_Response(NDRPacket):
 
 class GetConditionalPolicy_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrPolicyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrPolicyName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
 class GetConditionalPolicy_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrPolicyInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrPolicyInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1629,7 +1787,9 @@ class GetConditionalPolicy_Response(NDRPacket):
 
 class SetConditionalPolicy_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrPolicyInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrPolicyInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1672,15 +1832,21 @@ register_com_interface(
 
 class GetResourceGroupInfo_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrResourceGroupName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrResourceGroupName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        )
     ]
 
 
 class GetResourceGroupInfo_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrResourceGroupInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrResourceGroupInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -1689,7 +1855,11 @@ class GetResourceGroupInfo_Response(NDRPacket):
 
 class ModifyResourceGroup_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrResourceGroupInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrResourceGroupInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
         NDRSignedIntField("bOverwrite", 0),
     ]
 
@@ -1700,7 +1870,11 @@ class ModifyResourceGroup_Response(NDRPacket):
 
 class CreateResourceGroup_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrResourceGroupInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrResourceGroupInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        )
     ]
 
 
@@ -1710,7 +1884,11 @@ class CreateResourceGroup_Response(NDRPacket):
 
 class DeleteResourceGroup_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrResourceGroupName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrResourceGroupName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        )
     ]
 
 
@@ -1720,11 +1898,15 @@ class DeleteResourceGroup_Response(NDRPacket):
 
 class RenameResourceGroup_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField(
-            "bstrNewResourceGroupName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrNewResourceGroupName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         ),
-        NDRPacketField(
-            "bstrOldResourceGroupName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrOldResourceGroupName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         ),
     ]
 
@@ -1755,10 +1937,16 @@ register_com_interface(
 
 class CreateAccountingDb_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrServerName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrServerName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("bWindowsAuth", 0),
-        NDRPacketField("bstrUserName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrPasswd", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrUserName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrPasswd", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -1773,7 +1961,9 @@ class GetAccountingMetadata_Request(NDRPacket):
 class GetAccountingMetadata_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrMetaData", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrMetaData", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1781,16 +1971,26 @@ class GetAccountingMetadata_Response(NDRPacket):
 
 class ExecuteAccountingQuery_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrAccountingQuery", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrStartingDate", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrEndingDate", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrAccountingQuery", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrStartingDate", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrEndingDate", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
 class ExecuteAccountingQuery_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrResult", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrResult", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRSignedIntField("pbIsThereMoreData", 0),
         NDRIntField("status", 0),
@@ -1799,16 +1999,24 @@ class ExecuteAccountingQuery_Response(NDRPacket):
 
 class GetRawAccountingData_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrStartingDate", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrEndingDate", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrMachineName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrStartingDate", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrEndingDate", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrMachineName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
 class GetRawAccountingData_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrResult", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrResult", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRSignedIntField("pbIsThereMoreData", 0),
         NDRIntField("status", 0),
@@ -1822,7 +2030,9 @@ class GetNextAccountingDataBatch_Request(NDRPacket):
 class GetNextAccountingDataBatch_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrResult", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrResult", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRSignedIntField("pbIsThereMoreData", 0),
         NDRIntField("status", 0),
@@ -1831,9 +2041,15 @@ class GetNextAccountingDataBatch_Response(NDRPacket):
 
 class DeleteAccountingData_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrStartingDate", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrEndingDate", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrMachineName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrStartingDate", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrEndingDate", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrMachineName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -1859,7 +2075,9 @@ class CancelAccountingQuery_Response(NDRPacket):
 
 class RegisterAccountingClient_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrClientId", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrClientId", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1869,7 +2087,9 @@ class RegisterAccountingClient_Response(NDRPacket):
 
 class DumpAccountingData_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrAccountingData", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrAccountingData", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1884,7 +2104,9 @@ class GetAccountingClients_Request(NDRPacket):
 class GetAccountingClients_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrClientIds", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrClientIds", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1892,7 +2114,9 @@ class GetAccountingClients_Response(NDRPacket):
 
 class SetAccountingClientStatus_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrClientIds", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrClientIds", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -1910,7 +2134,9 @@ class CheckAccountingConnection_Response(NDRPacket):
 
 class SetClientPermissions_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrClientId", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrClientId", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRSignedIntField("fAddPermissions", 0),
     ]
 
@@ -1963,7 +2189,11 @@ class GetConfig_Request(NDRPacket):
 class GetConfig_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrConfigInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrConfigInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -1971,7 +2201,9 @@ class GetConfig_Response(NDRPacket):
 
 class SetConfig_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrConfigInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrConfigInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRIntEnumField("enumConfigType", 0, CONFIGTYPE),
     ]
 
@@ -2012,7 +2244,11 @@ class GetExclusionList_Request(NDRPacket):
 class GetExclusionList_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrExclusionList", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrExclusionList", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2020,7 +2256,9 @@ class GetExclusionList_Response(NDRPacket):
 
 class SetExclusionList_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrExclusionList", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrExclusionList", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -2083,8 +2321,10 @@ class GetSupportedClient_Request(NDRPacket):
 class GetSupportedClient_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrSupportedClients", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrSupportedClients", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -2109,10 +2349,16 @@ register_com_interface(
 
 class CreateMachineGroup_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField(
-            "bstrParentMachineGroupId", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrParentMachineGroupId", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         ),
-        NDRPacketField("bstrMachineGroupInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrMachineGroupInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
     ]
 
 
@@ -2122,15 +2368,19 @@ class CreateMachineGroup_Response(NDRPacket):
 
 class GetMachineGroupInfo_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrMachineGroupId", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrMachineGroupId", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
 class GetMachineGroupInfo_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrMachineGroupInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrMachineGroupInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -2146,8 +2396,14 @@ class MACHINE_GROUP_MERGE_OPTIONS(IntEnum):
 
 class ModifyMachineGroup_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrMachineGroupId", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrMachineGroupInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrMachineGroupId", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrMachineGroupInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
         NDRIntEnumField("enumMGMergeOptions", 0, MACHINE_GROUP_MERGE_OPTIONS),
     ]
 
@@ -2158,7 +2414,9 @@ class ModifyMachineGroup_Response(NDRPacket):
 
 class DeleteMachineGroup_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrMachineGroupId", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrMachineGroupId", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
@@ -2168,11 +2426,15 @@ class DeleteMachineGroup_Response(NDRPacket):
 
 class RenameMachineGroup_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField(
-            "bstrOldMachineGroupName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrOldMachineGroupName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         ),
-        NDRPacketField(
-            "bstrNewMachineGroupName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrNewMachineGroupName", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         ),
     ]
 
@@ -2183,10 +2445,14 @@ class RenameMachineGroup_Response(NDRPacket):
 
 class AddMachine_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField(
-            "bstrParentMachineGroupId", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrParentMachineGroupId", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         ),
-        NDRPacketField("bstrMachineInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrMachineInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -2196,14 +2462,20 @@ class AddMachine_Response(NDRPacket):
 
 class GetMachineInfo_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrMachineId", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        NDRFullPointerField(
+            NDRPacketField("bstrMachineId", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        )
     ]
 
 
 class GetMachineInfo_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrMachineInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrMachineInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2211,11 +2483,17 @@ class GetMachineInfo_Response(NDRPacket):
 
 class ModifyMachineInfo_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField(
-            "bstrParentMachineGroupId", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrParentMachineGroupId", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         ),
-        NDRPacketField("bstrMachineId", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrMachineInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrMachineId", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrMachineInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -2225,10 +2503,14 @@ class ModifyMachineInfo_Response(NDRPacket):
 
 class DeleteMachine_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField(
-            "bstrParentMachineGroupId", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrParentMachineGroupId", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         ),
-        NDRPacketField("bstrMachineId", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrMachineId", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
     ]
 
 
@@ -2262,7 +2544,9 @@ register_com_interface(
 
 class ExportObjects_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrObjectIds", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrObjectIds", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
         NDRIntEnumField("enumObjectType", 0, OBJECT_TYPE),
     ]
 
@@ -2270,7 +2554,9 @@ class ExportObjects_Request(NDRPacket):
 class ExportObjects_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrObjectXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            NDRFullPointerField(
+                NDRPacketField("pbstrObjectXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2278,20 +2564,38 @@ class ExportObjects_Response(NDRPacket):
 
 class GetImportConflicts_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrPMCXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrPolicyXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrCalendarXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrConditionalXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrMachineGroupXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrConfigurationXmls", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrPMCXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrPolicyXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrCalendarXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrConditionalXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrMachineGroupXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrConfigurationXmls", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
     ]
 
 
 class GetImportConflicts_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrConflictingObjects", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrConflictingObjects", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -2308,12 +2612,28 @@ class IMPORT_TYPE(IntEnum):
 
 class ImportXml_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField("bstrPMCXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrPolicyXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrCalendarXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrConditionalXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrMachineGroupXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
-        NDRPacketField("bstrConfigurationXmls", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB),
+        NDRFullPointerField(
+            NDRPacketField("bstrPMCXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrPolicyXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrCalendarXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField("bstrConditionalXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
+        ),
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrMachineGroupXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrConfigurationXmls", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
+        ),
         NDRIntEnumField("enumImportType", 0, IMPORT_TYPE),
     ]
 
@@ -2329,27 +2649,41 @@ class ExportXml_Request(NDRPacket):
 class ExportXml_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pbstrPMCXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
-        ),
-        NDRFullPointerField(
-            NDRPacketField("pbstrPolicyXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
-        ),
-        NDRFullPointerField(
-            NDRPacketField("pbstrCalendarXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
-        ),
-        NDRFullPointerField(
-            NDRPacketField(
-                "pbstrConditionalXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField("pbstrPMCXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
             )
         ),
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrMachineGroupXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField("pbstrPolicyXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
             )
         ),
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrConfigurationXmls", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrCalendarXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
+        ),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrConditionalXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
+        ),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrMachineGroupXml", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
+            )
+        ),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrConfigurationXmls", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -2382,8 +2716,12 @@ class GetRemoteUserCategories_Request(NDRPacket):
 class GetRemoteUserCategories_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField(
-                "pbstrRemoteUserCategoriesInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            NDRFullPointerField(
+                NDRPacketField(
+                    "pbstrRemoteUserCategoriesInfo",
+                    FLAGGED_WORD_BLOB(),
+                    FLAGGED_WORD_BLOB,
+                )
             )
         ),
         NDRIntField("status", 0),
@@ -2392,8 +2730,10 @@ class GetRemoteUserCategories_Response(NDRPacket):
 
 class SetRemoteUserCategories_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField(
-            "bstrRemoteUserCategoriesInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrRemoteUserCategoriesInfo", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         )
     ]
 
@@ -2404,8 +2744,10 @@ class SetRemoteUserCategories_Response(NDRPacket):
 
 class RefreshRemoteSessionWeights_Request(NDRPacket):
     fields_desc = [
-        NDRPacketField(
-            "bstrTaregetUserSessions", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+        NDRFullPointerField(
+            NDRPacketField(
+                "bstrTaregetUserSessions", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB
+            )
         ),
         NDRSignedIntField("bUpdateAll", 0),
     ]

--- a/scapy-rpc/msrpcs/oaidl.py
+++ b/scapy-rpc/msrpcs/oaidl.py
@@ -1408,7 +1408,9 @@ class SetCustData_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("guid", GUID(), GUID),
         NDRFullPointerField(
-            NDRPacketField("pVarVal", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVarVal", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
     ]
 
@@ -1422,7 +1424,9 @@ class SetFuncCustData_Request(NDRPacket):
         NDRIntField("index", 0),
         NDRPacketField("guid", GUID(), GUID),
         NDRFullPointerField(
-            NDRPacketField("pVarVal", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVarVal", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
     ]
 
@@ -1437,7 +1441,9 @@ class SetParamCustData_Request(NDRPacket):
         NDRIntField("indexParam", 0),
         NDRPacketField("guid", GUID(), GUID),
         NDRFullPointerField(
-            NDRPacketField("pVarVal", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVarVal", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
     ]
 
@@ -1451,7 +1457,9 @@ class SetVarCustData_Request(NDRPacket):
         NDRIntField("index", 0),
         NDRPacketField("guid", GUID(), GUID),
         NDRFullPointerField(
-            NDRPacketField("pVarVal", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVarVal", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
     ]
 
@@ -1465,7 +1473,9 @@ class SetImplTypeCustData_Request(NDRPacket):
         NDRIntField("index", 0),
         NDRPacketField("guid", GUID(), GUID),
         NDRFullPointerField(
-            NDRPacketField("pVarVal", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVarVal", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
     ]
 
@@ -1695,7 +1705,9 @@ class SetCustData_Request(NDRPacket):
     fields_desc = [
         NDRPacketField("guid", GUID(), GUID),
         NDRFullPointerField(
-            NDRPacketField("pVarVal", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pVarVal", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
     ]
 
@@ -2104,7 +2116,9 @@ class GetField_Request(NDRPacket):
 class GetField_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pvarField", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pvarField", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         NDRIntField("status", 0),
     ]
@@ -2120,7 +2134,9 @@ class GetFieldNoCopy_Request(NDRPacket):
 class GetFieldNoCopy_Response(NDRPacket):
     fields_desc = [
         NDRFullPointerField(
-            NDRPacketField("pvarField", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pvarField", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
         StrFixedLenField("ppvDataCArray", "", length=0),
         NDRIntField("status", 0),
@@ -2133,7 +2149,9 @@ class PutField_Request(NDRPacket):
         StrFixedLenField("pvData", "", length=0),
         NDRConfVarStrNullFieldUtf16("szFieldName", ""),
         NDRFullPointerField(
-            NDRPacketField("pvarField", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pvarField", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
     ]
 
@@ -2148,7 +2166,9 @@ class PutFieldNoCopy_Request(NDRPacket):
         StrFixedLenField("pvData", "", length=0),
         NDRConfVarStrNullFieldUtf16("szFieldName", ""),
         NDRFullPointerField(
-            NDRPacketField("pvarField", wireVARIANTStr(), wireVARIANTStr)
+            NDRFullPointerField(
+                NDRPacketField("pvarField", wireVARIANTStr(), wireVARIANTStr)
+            )
         ),
     ]
 
@@ -2278,7 +2298,11 @@ register_com_interface(
 class Read_Request(NDRPacket):
     fields_desc = [
         NDRConfVarStrNullFieldUtf16("pszPropName", ""),
-        NDRFullPointerField(NDRPacketField("pVar", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("pVar", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
         NDRFullPointerField(
             NDRPacketField("pErrorLog", MInterfacePointer(), MInterfacePointer)
         ),
@@ -2287,7 +2311,11 @@ class Read_Request(NDRPacket):
 
 class Read_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("pVar", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("pVar", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
@@ -2305,7 +2333,11 @@ class RemoteRead_Request(NDRPacket):
 
 class RemoteRead_Response(NDRPacket):
     fields_desc = [
-        NDRFullPointerField(NDRPacketField("pVar", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("pVar", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
         NDRIntField("status", 0),
     ]
 
@@ -2313,7 +2345,11 @@ class RemoteRead_Response(NDRPacket):
 class Write_Request(NDRPacket):
     fields_desc = [
         NDRConfVarStrNullFieldUtf16("pszPropName", ""),
-        NDRFullPointerField(NDRPacketField("pVar", wireVARIANTStr(), wireVARIANTStr)),
+        NDRFullPointerField(
+            NDRFullPointerField(
+                NDRPacketField("pVar", wireVARIANTStr(), wireVARIANTStr)
+            )
+        ),
     ]
 
 


### PR DESCRIPTION
I discovered that there is a problem in some of the "midl compiled to scapy" files.
The problem appears on the BSTR type function inputs but maybe not only.

From specifications [MS-OAUT], this type is defined by:
```
 typedef [unique] FLAGGED_WORD_BLOB* BSTR;
```

In Scapy example [MS-DCOM] (https://scapy.readthedocs.io/en/latest/layers/dcom.html) calling GetDataCollectorSets ([MS-PLA]) works while there is BSTR input.
On this interface, the BSTR inputs are compiled encapsulated in *NDRFullPointerField* because the *unique* attribute is set explicitly and during compilation this idl attribute take place for the pointer (instead of ref by default on top level).

```
# ms-pla.idl
interface IDataCollectorSetCollection : IDispatch
     {
         [propget, id(1)] HRESULT Count([out, retval] long* retVal);
         [propget, id(DISPID_VALUE)] HRESULT Item([in] VARIANT index, [out, retval] IDataCollectorSet** set);
         [propget, id(DISPID_NEWENUM)] HRESULT _NewEnum([out, retval] IUnknown** retVal);
  
         HRESULT Add(IDataCollectorSet* set);
         HRESULT Remove(VARIANT set);
         HRESULT Clear();
         HRESULT AddRange(IDataCollectorSetCollection* sets);
  
         HRESULT GetDataCollectorSets([in, unique] BSTR server, [in, unique] BSTR filter);
     }
```

```
# ms_pla.py
class GetDataCollectorSets_Request(NDRPacket):
    fields_desc = [
        NDRFullPointerField(
            NDRPacketField("server", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
        ),
        NDRFullPointerField(
            NDRPacketField("filter", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
        ),
    ]
```

While in other interfaces like in [MC-IISA], the *unique* attribute is not set explicitly and so the input parameter `bstrMetadataType` is not encapasulated in a *NDRFullPointerField* while they must be (due to the idl *unique* attribute of FLAGGED_WORD_BLOB pointer), instead the default ref attribute on top level pointer take place.

```
#mc-iisa.idl
HRESULT GetMetadata(
     [in] BSTR bstrMetadataType,
     [out, retval] VARIANT * pValue
   );
```

```
# mc_iisa.py
class GetMetadata_Request(NDRPacket):
    fields_desc = [
        NDRPacketField("bstrMetadataType", FLAGGED_WORD_BLOB(), FLAGGED_WORD_BLOB)
    ]
```

Reading the code, you have maybe already identified the problem as you said in you comment :
From midl_resolve.py, line 385
> The fact that we remove all pointer attributes from children is technically
> slightly broken. We should ideally remove them only if they were added because
> they were the default value, and also not store default values in the environment.

I tried to add an additionnal attribute on the compilation classes that keeps track of the default attribute 
and replacing the condition of not adding idl attribute if it is a ref, unique, or ptr
by if it is not the default.
I need to modify two files: midl_resolve.py, scapy_obj.py 

```
idl_attributes += [
                    x
                    for x in new_arg.idl_attributes
                    if x not in idl_attributes and x not in ("ref", "unique", "ptr")
                ] 
```
```
idl_attributes += [
                    x
                    for x in new_arg.idl_attributes
                    if x not in idl_attributes and x != new_arg.default_idl_attribute
                ]
```
But, it is certainly more complex to solve this issue because recompiling all idl file leads to 51 files modified out of 115.
